### PR TITLE
fix: improve progress reporting

### DIFF
--- a/packages/pyright-scip/package-lock.json
+++ b/packages/pyright-scip/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sourcegraph/scip-python",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sourcegraph/scip-python",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^9.2.0",
@@ -29,6 +29,7 @@
         "@types/google-protobuf": "^3.15.5",
         "@types/jest": "^27.5.0",
         "@types/ora": "^3.2.0",
+        "clean-terminal-webpack-plugin": "^3.0.0",
         "copy-webpack-plugin": "^10.2.0",
         "jest": "^27.4.7",
         "jest-junit": "^13.0.0",
@@ -2834,6 +2835,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/clean-terminal-webpack-plugin": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/clean-terminal-webpack-plugin/-/clean-terminal-webpack-plugin-3.0.0.tgz",
+      "integrity": "sha512-wcgkQZmwEWYYjHblXc0+UGFDtx37S+1qgUQl4EOhhinzSHbZpixWBiasQ91RoCMf5lAm67j1XOt9z+HN+sWkWA==",
+      "dev": true,
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/cli-cursor": {
@@ -11966,6 +11976,13 @@
           "dev": true
         }
       }
+    },
+    "clean-terminal-webpack-plugin": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/clean-terminal-webpack-plugin/-/clean-terminal-webpack-plugin-3.0.0.tgz",
+      "integrity": "sha512-wcgkQZmwEWYYjHblXc0+UGFDtx37S+1qgUQl4EOhhinzSHbZpixWBiasQ91RoCMf5lAm67j1XOt9z+HN+sWkWA==",
+      "dev": true,
+      "requires": {}
     },
     "cli-cursor": {
       "version": "4.0.0",

--- a/packages/pyright-scip/package-lock.json
+++ b/packages/pyright-scip/package-lock.json
@@ -13,7 +13,6 @@
         "diff": "^5.0.0",
         "glob": "^7.2.0",
         "google-protobuf": "^3.19.3",
-        "ora": "^6.1.0",
         "ts-node": "^10.5.0",
         "vscode-languageserver": "^7.0.0"
       },
@@ -2569,6 +2568,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2599,6 +2599,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-5.0.0.tgz",
       "integrity": "sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==",
+      "dev": true,
       "dependencies": {
         "buffer": "^6.0.3",
         "inherits": "^2.0.4",
@@ -2686,6 +2687,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2850,6 +2852,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
       "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "dev": true,
       "dependencies": {
         "restore-cursor": "^4.0.0"
       },
@@ -2864,6 +2867,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
       "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       },
@@ -2886,6 +2890,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -3198,6 +3203,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "dev": true,
       "dependencies": {
         "clone": "^1.0.2"
       }
@@ -4788,6 +4794,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5022,6 +5029,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
       "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -5163,6 +5171,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.2.0.tgz",
       "integrity": "sha512-wH+U77omcRzevfIG8dDhTS0V9zZyweakfD01FULl97+0EHiJTTZtJqxPSkIIo/SDPv/i07k/C9jAPY+jwLLeUQ==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -6981,6 +6990,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
       "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
+      "dev": true,
       "dependencies": {
         "chalk": "^5.0.0",
         "is-unicode-supported": "^1.1.0"
@@ -6996,6 +7006,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
       "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "dev": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -7127,6 +7138,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -7362,6 +7374,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -7394,6 +7407,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ora/-/ora-6.1.0.tgz",
       "integrity": "sha512-CxEP6845hLK+NHFWZ+LplGO4zfw4QSfxTlqMfvlJ988GoiUeZDMzCvqsZkFHv69sPICmJH1MDxZoQFOKXerAVw==",
+      "dev": true,
       "dependencies": {
         "bl": "^5.0.0",
         "chalk": "^5.0.0",
@@ -7416,6 +7430,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -7427,6 +7442,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
       "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "dev": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -7438,6 +7454,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
       "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -7916,6 +7933,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -8084,6 +8102,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
       "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "dev": true,
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -8354,7 +8373,8 @@
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -8480,6 +8500,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -8488,6 +8509,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9222,7 +9244,8 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -9358,6 +9381,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "dev": true,
       "dependencies": {
         "defaults": "^1.0.3"
       }
@@ -11793,7 +11817,8 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
     },
     "bent": {
       "version": "7.3.12",
@@ -11810,6 +11835,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-5.0.0.tgz",
       "integrity": "sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==",
+      "dev": true,
       "requires": {
         "buffer": "^6.0.3",
         "inherits": "^2.0.4",
@@ -11875,6 +11901,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -11988,6 +12015,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
       "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "dev": true,
       "requires": {
         "restore-cursor": "^4.0.0"
       }
@@ -11995,7 +12023,8 @@
     "cli-spinners": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
-      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g=="
+      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
+      "dev": true
     },
     "cliui": {
       "version": "7.0.4",
@@ -12011,7 +12040,8 @@
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true
     },
     "clone-deep": {
       "version": "4.0.1",
@@ -12244,6 +12274,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "dev": true,
       "requires": {
         "clone": "^1.0.2"
       }
@@ -13445,7 +13476,8 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
     },
     "ignore": {
       "version": "5.2.0",
@@ -13596,7 +13628,8 @@
     "is-interactive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true
     },
     "is-negative-zero": {
       "version": "2.0.2",
@@ -13686,7 +13719,8 @@
     "is-unicode-supported": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.2.0.tgz",
-      "integrity": "sha512-wH+U77omcRzevfIG8dDhTS0V9zZyweakfD01FULl97+0EHiJTTZtJqxPSkIIo/SDPv/i07k/C9jAPY+jwLLeUQ=="
+      "integrity": "sha512-wH+U77omcRzevfIG8dDhTS0V9zZyweakfD01FULl97+0EHiJTTZtJqxPSkIIo/SDPv/i07k/C9jAPY+jwLLeUQ==",
+      "dev": true
     },
     "is-weakref": {
       "version": "1.0.2",
@@ -15165,6 +15199,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
       "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
+      "dev": true,
       "requires": {
         "chalk": "^5.0.0",
         "is-unicode-supported": "^1.1.0"
@@ -15173,7 +15208,8 @@
         "chalk": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-          "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
+          "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+          "dev": true
         }
       }
     },
@@ -15272,7 +15308,8 @@
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.1.2",
@@ -15456,6 +15493,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -15479,6 +15517,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ora/-/ora-6.1.0.tgz",
       "integrity": "sha512-CxEP6845hLK+NHFWZ+LplGO4zfw4QSfxTlqMfvlJ988GoiUeZDMzCvqsZkFHv69sPICmJH1MDxZoQFOKXerAVw==",
+      "dev": true,
       "requires": {
         "bl": "^5.0.0",
         "chalk": "^5.0.0",
@@ -15494,17 +15533,20 @@
         "ansi-regex": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+          "dev": true
         },
         "chalk": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-          "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
+          "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+          "dev": true
         },
         "strip-ansi": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
           "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^6.0.1"
           }
@@ -15856,6 +15898,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -15975,6 +16018,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
       "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "dev": true,
       "requires": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -16167,7 +16211,8 @@
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -16276,6 +16321,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       },
@@ -16283,7 +16329,8 @@
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
         }
       }
     },
@@ -16793,7 +16840,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "uuid": {
       "version": "8.3.2",
@@ -16910,6 +16958,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "dev": true,
       "requires": {
         "defaults": "^1.0.3"
       }

--- a/packages/pyright-scip/package.json
+++ b/packages/pyright-scip/package.json
@@ -11,7 +11,8 @@
     "update-snapshots": "node ./index.js snapshot-dir snapshots --environment snapshots/testEnv.json --no-progress-bar",
     "test": "jest --forceExit --detectOpenHandles",
     "webpack": "webpack --mode development --progress",
-    "watch": "webpack --mode development --progress --watch"
+    "watch": "webpack --mode development --progress --watch",
+    "yup": "webpack --help"
   },
   "author": "Sourcegraph",
   "repository": {
@@ -29,6 +30,7 @@
     "@types/google-protobuf": "^3.15.5",
     "@types/jest": "^27.5.0",
     "@types/ora": "^3.2.0",
+    "clean-terminal-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^10.2.0",
     "jest": "^27.4.7",
     "jest-junit": "^13.0.0",

--- a/packages/pyright-scip/package.json
+++ b/packages/pyright-scip/package.json
@@ -11,8 +11,7 @@
     "update-snapshots": "node ./index.js snapshot-dir snapshots --environment snapshots/testEnv.json --no-progress-bar",
     "test": "jest --forceExit --detectOpenHandles",
     "webpack": "webpack --mode development --progress",
-    "watch": "webpack --mode development --progress --watch",
-    "yup": "webpack --help"
+    "watch": "webpack --mode development --progress --watch"
   },
   "author": "Sourcegraph",
   "repository": {

--- a/packages/pyright-scip/package.json
+++ b/packages/pyright-scip/package.json
@@ -47,7 +47,6 @@
     "diff": "^5.0.0",
     "glob": "^7.2.0",
     "google-protobuf": "^3.19.3",
-    "ora": "^6.1.0",
     "ts-node": "^10.5.0",
     "vscode-languageserver": "^7.0.0"
   },

--- a/packages/pyright-scip/src/MainCommand.test.ts
+++ b/packages/pyright-scip/src/MainCommand.test.ts
@@ -18,11 +18,11 @@ function checkIndexParser(args: string[], expectedOptions: Partial<IndexOptions>
 
 // defaults
 checkIndexParser([], {
-    progressBar: true,
+    quiet: false,
     cwd: process.cwd(),
     output: DEFAULT_OUTPUT_FILE,
     projectName: 'snapshot-util',
 });
 
 checkIndexParser(['--cwd', 'qux'], { cwd: 'qux' });
-checkIndexParser(['--no-progress-bar'], { progressBar: false });
+checkIndexParser(['--no-progress-bar'], { quiet: false });

--- a/packages/pyright-scip/src/MainCommand.test.ts
+++ b/packages/pyright-scip/src/MainCommand.test.ts
@@ -26,3 +26,4 @@ checkIndexParser([], {
 
 checkIndexParser(['--cwd', 'qux'], { cwd: 'qux' });
 checkIndexParser(['--no-progress-bar'], { quiet: false });
+checkIndexParser(['--show-progress-rate-limit', '120'], { showProgressRateLimit: 120 });

--- a/packages/pyright-scip/src/MainCommand.test.ts
+++ b/packages/pyright-scip/src/MainCommand.test.ts
@@ -27,3 +27,4 @@ checkIndexParser([], {
 checkIndexParser(['--cwd', 'qux'], { cwd: 'qux' });
 checkIndexParser(['--no-progress-bar'], { quiet: false });
 checkIndexParser(['--show-progress-rate-limit', '120'], { showProgressRateLimit: 120 });
+checkIndexParser(['--show-progress-rate-limit', '0.5'], { showProgressRateLimit: 0.5 });

--- a/packages/pyright-scip/src/MainCommand.ts
+++ b/packages/pyright-scip/src/MainCommand.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander';
+import { Command, InvalidArgumentError } from 'commander';
 import packageJson from '../package.json';
 
 export interface IndexOptions {
@@ -12,7 +12,10 @@ export interface IndexOptions {
     exclude: string;
     output: string;
     cwd: string;
+
+    // Progress reporting configuration
     quiet: boolean;
+    showProgressRateLimit: number | undefined;
 }
 
 export interface SnapshotOptions extends IndexOptions {
@@ -26,6 +29,19 @@ export interface EnvironmentOptions {
 }
 
 export const DEFAULT_OUTPUT_FILE = 'index.scip';
+
+const parseOptionalInt = (value: string) => {
+    if (value === undefined) {
+        return undefined;
+    }
+
+    // parseInt takes a string and a radix
+    const parsedValue = parseInt(value, 10);
+    if (isNaN(parsedValue)) {
+        throw new InvalidArgumentError('Not a number.');
+    }
+    return parsedValue;
+};
 
 export function mainCommand(
     indexAction: (options: IndexOptions) => void,
@@ -44,6 +60,7 @@ export function mainCommand(
         .option('--snapshot-dir <path>', 'the directory to output a snapshot of the SCIP dump')
         .option('--no-progress-bar', '(deprecated, use "--quiet")')
         .option('--quiet', 'run without logging and status information', false)
+        .option('--show-progress-rate-limit <limit>', 'number of times to show progress per minute', parseOptionalInt)
         .option('--environment <json-file>', 'the environment json file (experimental)')
         .option('--include <pattern>', 'comma-separated list of patterns to include (experimental)')
         .option('--exclude <pattern>', 'comma-separated list of patterns to exclude (experimental)')
@@ -61,9 +78,10 @@ export function mainCommand(
         .option('--project-version <version>', 'the name of the current project, pypi name if applicable', '0.1')
         .option('--output <path>', 'path to the output file', DEFAULT_OUTPUT_FILE)
         .option('--environment <json-file>', 'the environment json file (experimental)')
-        .option('--no-index', 'skip indexing (and just use existing index.scip)')
+        .option('--no-index', 'skip indexing (use existing index.scip)')
         .option('--no-progress-bar', '(deprecated, use "--quiet")')
-        .option('--quiet', 'run without logging and status information', true)
+        .option('--quiet', 'run without logging and status information', false)
+        .option('--show-progress-rate-limit <limit>', 'number of times to show progress per minute', parseOptionalInt)
         .action((dir, parsedOptions) => {
             snapshotAction(dir, parsedOptions as SnapshotOptions);
         });

--- a/packages/pyright-scip/src/MainCommand.ts
+++ b/packages/pyright-scip/src/MainCommand.ts
@@ -30,13 +30,13 @@ export interface EnvironmentOptions {
 
 export const DEFAULT_OUTPUT_FILE = 'index.scip';
 
-const parseOptionalInt = (value: string) => {
+const parseOptionalNum = (value: string) => {
     if (value === undefined) {
         return undefined;
     }
 
     // parseInt takes a string and a radix
-    const parsedValue = parseInt(value, 10);
+    const parsedValue = parseFloat(value);
     if (isNaN(parsedValue)) {
         throw new InvalidArgumentError('Not a number.');
     }
@@ -60,7 +60,11 @@ export function mainCommand(
         .option('--snapshot-dir <path>', 'the directory to output a snapshot of the SCIP dump')
         .option('--no-progress-bar', '(deprecated, use "--quiet")')
         .option('--quiet', 'run without logging and status information', false)
-        .option('--show-progress-rate-limit <limit>', 'number of times to show progress per minute', parseOptionalInt)
+        .option(
+            '--show-progress-rate-limit <limit>',
+            'minimum number of seconds between progress messages in the output.',
+            parseOptionalNum
+        )
         .option('--environment <json-file>', 'the environment json file (experimental)')
         .option('--include <pattern>', 'comma-separated list of patterns to include (experimental)')
         .option('--exclude <pattern>', 'comma-separated list of patterns to exclude (experimental)')
@@ -81,7 +85,11 @@ export function mainCommand(
         .option('--no-index', 'skip indexing (use existing index.scip)')
         .option('--no-progress-bar', '(deprecated, use "--quiet")')
         .option('--quiet', 'run without logging and status information', false)
-        .option('--show-progress-rate-limit <limit>', 'number of times to show progress per minute', parseOptionalInt)
+        .option(
+            '--show-progress-rate-limit <limit>',
+            'minimum number of seconds between progress messages in the output.',
+            parseOptionalNum
+        )
         .action((dir, parsedOptions) => {
             snapshotAction(dir, parsedOptions as SnapshotOptions);
         });

--- a/packages/pyright-scip/src/MainCommand.ts
+++ b/packages/pyright-scip/src/MainCommand.ts
@@ -12,7 +12,7 @@ export interface IndexOptions {
     exclude: string;
     output: string;
     cwd: string;
-    progressBar: boolean;
+    quiet: boolean;
 }
 
 export interface SnapshotOptions extends IndexOptions {
@@ -42,7 +42,8 @@ export function mainCommand(
         .option('--cwd <path>', 'working directory for executing scip-python', process.cwd())
         .option('--output <path>', 'path to the output file', DEFAULT_OUTPUT_FILE)
         .option('--snapshot-dir <path>', 'the directory to output a snapshot of the SCIP dump')
-        .option('--no-progress-bar', 'whether to disable the progress bar')
+        .option('--no-progress-bar', '(deprecated, use "--quiet")')
+        .option('--quiet', 'run without logging and status information', false)
         .option('--environment <json-file>', 'the environment json file (experimental)')
         .option('--include <pattern>', 'comma-separated list of patterns to include (experimental)')
         .option('--exclude <pattern>', 'comma-separated list of patterns to exclude (experimental)')
@@ -61,7 +62,8 @@ export function mainCommand(
         .option('--output <path>', 'path to the output file', DEFAULT_OUTPUT_FILE)
         .option('--environment <json-file>', 'the environment json file (experimental)')
         .option('--no-index', 'skip indexing (and just use existing index.scip)')
-        .option('--no-progress-bar', 'whether to disable the progress bar')
+        .option('--no-progress-bar', '(deprecated, use "--quiet")')
+        .option('--quiet', 'run without logging and status information', true)
         .action((dir, parsedOptions) => {
             snapshotAction(dir, parsedOptions as SnapshotOptions);
         });

--- a/packages/pyright-scip/src/indexer.ts
+++ b/packages/pyright-scip/src/indexer.ts
@@ -106,10 +106,8 @@ export class Indexer {
         });
 
         let projectSourceFiles: SourceFile[] = [];
-        withStatus('Index workspace and track project files', (spinner) => {
+        withStatus('Index workspace and track project files', () => {
             this.program.indexWorkspace((filepath: string, _results: IndexResults) => {
-                spinner.render();
-
                 // Filter out filepaths not part of this project
                 if (filepath.indexOf(this.scipConfig.projectRoot) != 0) {
                     return;
@@ -133,14 +131,14 @@ export class Indexer {
             sourceFile.markDirty(true);
         });
 
-        while (this.program.analyze()) {}
+        withStatus('Analyze project and dependencies', () => {
+            while (this.program.analyze()) {}
+        });
 
         let externalSymbols: Map<string, scip.SymbolInformation> = new Map();
-        withStatus('Parse and emit SCIP', (spinner) => {
+        withStatus('Parse and emit SCIP', () => {
             const typeEvaluator = this.program.evaluator!;
             projectSourceFiles.forEach((sourceFile) => {
-                spinner.render();
-
                 const filepath = sourceFile.getFilePath();
                 let doc = new scip.Document({
                     relative_path: path.relative(this.scipConfig.workspaceRoot, filepath),

--- a/packages/pyright-scip/src/main.ts
+++ b/packages/pyright-scip/src/main.ts
@@ -14,10 +14,9 @@ import { exit } from 'process';
 export function main(): void {
     const command = mainCommand(
         (options) => {
-            if (!options.progressBar) {
-                statusConfig.showProgress = false;
-            }
-            statusConfig.showProgress = false;
+            // Set quiet mode
+            statusConfig.quiet = options.quiet;
+            statusConfig.dev = options.dev;
 
             const workspaceRoot = options.cwd;
             const snapshotDir = options.snapshotDir;
@@ -90,7 +89,8 @@ export function main(): void {
             }
         },
         (snapshotRoot, options) => {
-            statusConfig.showProgress = false;
+            statusConfig.quiet = options.quiet;
+            statusConfig.dev = options.dev;
 
             console.log('... Snapshotting ... ');
             const projectName = options.projectName;

--- a/packages/pyright-scip/src/main.ts
+++ b/packages/pyright-scip/src/main.ts
@@ -7,15 +7,20 @@ import { diffSnapshot, formatSnapshot, writeSnapshot } from './lib';
 import { Input } from './lsif-typescript/Input';
 import { join } from 'path';
 import { mainCommand } from './MainCommand';
-import { sendStatus, statusConfig } from './status';
+import { sendStatus, setQuiet, setShowProgressRateLimit } from './status';
 import { Indexer } from './indexer';
 import { exit } from 'process';
 
 export function main(): void {
     const command = mainCommand(
         (options) => {
-            statusConfig.quiet = options.quiet;
-            statusConfig.dev = options.dev;
+            setQuiet(options.quiet);
+            if (options.showProgressRateLimit !== undefined) {
+                setShowProgressRateLimit(options.showProgressRateLimit);
+            }
+
+            console.log(options);
+            exit(1);
 
             const workspaceRoot = options.cwd;
             const snapshotDir = options.snapshotDir;
@@ -93,8 +98,10 @@ export function main(): void {
             }
         },
         (snapshotRoot, options) => {
-            statusConfig.quiet = options.quiet;
-            statusConfig.dev = options.dev;
+            setQuiet(options.quiet);
+            if (options.showProgressRateLimit !== undefined) {
+                setShowProgressRateLimit(options.showProgressRateLimit);
+            }
 
             console.log('... Snapshotting ... ');
             const projectName = options.projectName;

--- a/packages/pyright-scip/src/main.ts
+++ b/packages/pyright-scip/src/main.ts
@@ -19,9 +19,6 @@ export function main(): void {
                 setShowProgressRateLimit(options.showProgressRateLimit);
             }
 
-            console.log(options);
-            exit(1);
-
             const workspaceRoot = options.cwd;
             const snapshotDir = options.snapshotDir;
             const environment = options.environment;

--- a/packages/pyright-scip/src/status.ts
+++ b/packages/pyright-scip/src/status.ts
@@ -1,13 +1,10 @@
-export const statusConfig = {
-    quiet: true,
-    dev: false,
-};
+const statusConfig = { quiet: true };
 
 class Logger {
     private lastProgressMsg: Date;
 
     /// control the rate to no faster than showProgressRateLimit / 60 seconds
-    private showProgressRateLimit: number;
+    public showProgressRateLimit: number;
 
     public depth: number;
 
@@ -75,6 +72,14 @@ export interface StatusUpdater {
     /// Do not use within tight loops that could generate thousands of messages,
     /// instead use StatusUpdater.progress
     message: (msg: any) => void;
+}
+
+export function setQuiet(quiet: boolean): void {
+    statusConfig.quiet = quiet;
+}
+
+export function setShowProgressRateLimit(ratelimit: number): void {
+    logger.showProgressRateLimit = ratelimit;
 }
 
 export function withStatus<T>(msg: string, f: (progress: StatusUpdater) => T): T {

--- a/packages/pyright-scip/src/status.ts
+++ b/packages/pyright-scip/src/status.ts
@@ -3,12 +3,12 @@ const statusConfig = { quiet: true };
 class Logger {
     private lastProgressMsg: Date;
 
-    /// control the rate to no faster than showProgressRateLimit / 60 seconds
+    /// Minimum number of seconds between progress messages in the output.
     public showProgressRateLimit: number;
 
     public depth: number;
 
-    constructor(showProgressRateLimit = 6) {
+    constructor(showProgressRateLimit = 1) {
         this.depth = 0;
         this.showProgressRateLimit = showProgressRateLimit;
         this.lastProgressMsg = new Date();
@@ -52,7 +52,7 @@ class Logger {
         if (
             this.showProgressRateLimit == 0 ||
             !this.lastProgressMsg ||
-            now.getTime() - this.lastProgressMsg.getTime() > (60 / this.showProgressRateLimit) * 1000
+            (now.getTime() - this.lastProgressMsg.getTime()) / 1000 > this.showProgressRateLimit
         ) {
             this.lastProgressMsg = now;
             this.write_message(this.depth + 1, '- ' + msg);

--- a/packages/pyright-scip/src/status.ts
+++ b/packages/pyright-scip/src/status.ts
@@ -3,15 +3,96 @@ export const statusConfig = {
     dev: false,
 };
 
-export interface StatusUpdater {
-    progress: (msg: any) => void;
-    progressDev: (msg: any) => void;
-}
+class Logger {
+    private lastProgressMsg: Date;
 
-export function withStatus<T>(msg: string, f: () => T): T {
-    if (!statusConfig.quiet) {
-        console.log(msg, '...');
+    /// control the rate to no faster than showProgressRateLimit / 60 seconds
+    private showProgressRateLimit: number;
+
+    public depth: number;
+
+    constructor(showProgressRateLimit = 6) {
+        this.depth = 0;
+        this.showProgressRateLimit = showProgressRateLimit;
+        this.lastProgressMsg = new Date();
     }
 
-    return f();
+    private timestamp(): string {
+        const now = new Date();
+        return `(${now.toLocaleTimeString('default', {
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+            hour12: false,
+        })}) `;
+    }
+
+    section(msg: string): void {
+        this.write_message(this.depth, msg);
+
+        this.depth += 1;
+        this.lastProgressMsg = new Date();
+    }
+
+    message(msg: string): void {
+        this.write_message(this.depth + 1, msg);
+    }
+
+    write_message(depth: number, msg: string): void {
+        process.stdout.write(this.timestamp());
+        if (depth > 0) {
+            process.stdout.write('  '.repeat(this.depth));
+        }
+        console.log(msg);
+    }
+
+    complete(): void {
+        this.depth -= 1;
+    }
+
+    progress(msg: string): void {
+        const now = new Date();
+        if (
+            this.showProgressRateLimit == 0 ||
+            !this.lastProgressMsg ||
+            now.getTime() - this.lastProgressMsg.getTime() > (60 / this.showProgressRateLimit) * 1000
+        ) {
+            this.lastProgressMsg = now;
+            this.write_message(this.depth + 1, '- ' + msg);
+        }
+    }
+}
+
+const logger = new Logger();
+
+export interface StatusUpdater {
+    /// Send a message at a certain interval (when enabled).
+    /// Use this to send messages that could be sent many times (which will prevent
+    /// messages being spammed in the logs)
+    progress: (msg: any) => void;
+
+    /// Messasge will always send a message (when enabled).
+    /// Do not use within tight loops that could generate thousands of messages,
+    /// instead use StatusUpdater.progress
+    message: (msg: any) => void;
+}
+
+export function withStatus<T>(msg: string, f: (progress: StatusUpdater) => T): T {
+    const progress = statusConfig.quiet
+        ? { section: () => {}, complete: () => {}, progress: (_: string) => {}, message: (_: string) => {} }
+        : logger;
+
+    progress.section(msg);
+    const val = f(progress);
+    progress.complete();
+
+    return val;
+}
+
+export function sendStatus(msg: string) {
+    if (statusConfig.quiet) {
+        return;
+    }
+
+    logger.write_message(0, msg);
 }

--- a/packages/pyright-scip/src/status.ts
+++ b/packages/pyright-scip/src/status.ts
@@ -1,22 +1,17 @@
-import ora, { Ora } from 'ora';
-
 export const statusConfig = {
-    showProgress: true,
+    quiet: true,
+    dev: false,
 };
 
-export function withStatus<T>(msg: string, f: (s: Ora) => T): T {
-    const spinner = ora({
-        text: msg,
-        spinner: 'arc',
-        interval: 100,
-    });
+export interface StatusUpdater {
+    progress: (msg: any) => void;
+    progressDev: (msg: any) => void;
+}
 
-    if (statusConfig.showProgress) {
-        spinner.start();
+export function withStatus<T>(msg: string, f: () => T): T {
+    if (!statusConfig.quiet) {
+        console.log(msg, '...');
     }
 
-    let v = f(spinner);
-
-    spinner.succeed();
-    return v;
+    return f();
 }

--- a/packages/pyright-scip/src/virtualenv/environment.ts
+++ b/packages/pyright-scip/src/virtualenv/environment.ts
@@ -37,19 +37,12 @@ export default function getEnvironment(
         return new PythonEnvironment(projectFiles, projectVersion, f);
     }
 
-    return withStatus('Evaluating python environment dependencies', (spinner) => {
+    return withStatus('Evaluating python environment dependencies', () => {
         const listed = pipList();
-
-        spinner.render();
         const bulk = pipBulkShow(listed.map((item) => item.name));
-
-        spinner.render();
         const info = bulk.map((shown) => {
-            spinner.render();
             return PythonPackage.fromPipShow(shown);
         });
-
-        spinner.render();
         return new PythonEnvironment(projectFiles, projectVersion, info);
     });
 }

--- a/packages/pyright-scip/src/virtualenv/environment.ts
+++ b/packages/pyright-scip/src/virtualenv/environment.ts
@@ -37,9 +37,13 @@ export default function getEnvironment(
         return new PythonEnvironment(projectFiles, projectVersion, f);
     }
 
-    return withStatus('Evaluating python environment dependencies', () => {
+    return withStatus('Evaluating python environment dependencies', (progress) => {
         const listed = pipList();
+
+        progress.message('Gathering environment information from `pip`');
         const bulk = pipBulkShow(listed.map((item) => item.name));
+
+        progress.message('Analyzing dependencies');
         const info = bulk.map((shown) => {
             return PythonPackage.fromPipShow(shown);
         });

--- a/packages/pyright-scip/webpack.config.js
+++ b/packages/pyright-scip/webpack.config.js
@@ -10,6 +10,7 @@ const path = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
 const { TsconfigPathsPlugin } = require('tsconfig-paths-webpack-plugin');
 const { monorepoResourceNameMapper } = require('../../build/lib/webpack');
+const CleanTerminalPlugin = require('clean-terminal-webpack-plugin');
 
 const outPath = path.resolve(__dirname, 'dist');
 const typeshedFallback = path.resolve(__dirname, '..', 'pyright-internal', 'typeshed-fallback');
@@ -58,7 +59,10 @@ module.exports = (_, { mode }) => {
                 },
             ],
         },
-        plugins: [new CopyPlugin({ patterns: [{ from: typeshedFallback, to: 'typeshed-fallback' }] })],
+        plugins: [
+            new CopyPlugin({ patterns: [{ from: typeshedFallback, to: 'typeshed-fallback' }] }),
+            new CleanTerminalPlugin(),
+        ],
         optimization: {
             splitChunks: {
                 cacheGroups: {


### PR DESCRIPTION
```
(08:20:00) Indexing /home/tjdevries/git/input/django with version 34e2148fc725e7200050f74130d7523e3cd8507a
(08:20:01) Evaluating python environment dependencies
(08:20:01)   Gathering environment information from `pip`
(08:20:03)   Analyzing dependencies
(08:20:03) Parse and search for dependencies
(08:20:13)   1101 / 4002
(08:20:23)   2279 / 4032
(08:20:33)   3111 / 4041
(08:20:41) Index workspace and track project files
(08:20:41) Analyze project and dependencies
(08:20:51)   1807 / 4053
(08:21:01)   2690 / 4053
(08:21:10) Parse and emit SCIP
(08:21:20)   - (1865/3612): /home/tjdevries/git/input/django/tests/aggregation_regress/__init__.py
(08:21:26) Writing external symbols to SCIP index
(08:21:26) Sucessfully wrote SCIP index to index.scip
(08:21:26) Writing snapshot from index: /home/tjdevries/git/input/django/index.scip
```

New options:
`--quiet` & `--show-progress-rate-limit X`


Additionally, traceback support has been improved:


```
❯ node ~/sourcegraph/scip-python/packages/pyright-scip/index.js index . --project-name django --show-progress-rate-limit 0.5
(09:27:24) Indexing /home/tjdevries/git/input/django with version 34e2148fc725e7200050f74130d7523e3cd8507a
(09:27:24) Evaluating python environment dependencies
(09:27:25)   Gathering environment information from `pip`
(09:27:27)   Analyzing dependencies
(09:27:27) Parse and search for dependencies
(09:27:37)   1118 / 4002
(09:27:47)   2336 / 4037
(09:27:57)   3341 / 4041
(09:28:02) Index workspace and track project files
(09:28:02) Analyze project and dependencies
(09:28:12)   1361 / 4053
(09:28:22)   2727 / 4053
(09:28:32)   3680 / 4053
(09:28:33) Parse and emit SCIP


Experienced Fatal Error While Indexing:
Please create an issue at github.com/sourcegraph/scip-python: {
  currentFilepath: '/home/tjdevries/git/input/django/setup.py',
  error: TypeError: Cannot read property 'y' of undefined
      at TreeVisitor.visitImport (/home/tjdevries/sourcegraph/scip-python/packages/pyright-scip/dist/scip-python.js:3554:16)
      at TreeVisitor.visitNode (/home/tjdevries/sourcegraph/scip-python/packages/pyright-scip/dist/pyright-internal.js:16854:29)
      at TreeVisitor.walk (/home/tjdevries/sourcegraph/scip-python/packages/pyright-scip/dist/pyright-internal.js:16787:37)
      at /home/tjdevries/sourcegraph/scip-python/packages/pyright-scip/dist/pyright-internal.js:16795:22
      at Array.forEach (<anonymous>)
      at TreeVisitor.walkMultiple (/home/tjdevries/sourcegraph/scip-python/packages/pyright-scip/dist/pyright-internal.js:16793:15)
      at TreeVisitor.walk (/home/tjdevries/sourcegraph/scip-python/packages/pyright-scip/dist/pyright-internal.js:16789:18)
      at /home/tjdevries/sourcegraph/scip-python/packages/pyright-scip/dist/pyright-internal.js:16795:22
      at Array.forEach (<anonymous>)
      at TreeVisitor.walkMultiple (/home/tjdevries/sourcegraph/scip-python/packages/pyright-scip/dist/pyright-internal.js:16793:15)
}
```