### PR TITLE
fix: Normalize name and version correctly

### DIFF
--- a/packages/pyright-scip/snapshots/output/odd_pkg_name_1/main.py
+++ b/packages/pyright-scip/snapshots/output/odd_pkg_name_1/main.py
@@ -1,13 +1,13 @@
-# < definition scip-python python package with space 0.1 main/__init__:
+# < definition scip-python python package  with  space 0.1 main/__init__:
 #documentation (module) main
 
 def main():
-#   ^^^^ definition  package with space 0.1 main/main().
+#   ^^^^ definition  package  with  space 0.1 main/main().
 #   documentation ```python
 #               > def main(): # -> None:
 #               > ```
     pass
 
 main()
-#^^^ reference  package with space 0.1 main/main().
+#^^^ reference  package  with  space 0.1 main/main().
 

--- a/packages/pyright-scip/src/ScipSymbol.ts
+++ b/packages/pyright-scip/src/ScipSymbol.ts
@@ -7,10 +7,21 @@ export class ScipSymbol extends TypescriptScipSymbol {
     }
 
     public static override package(name: string, version: string): TypescriptScipSymbol {
-        name = name.replace(/\./, '/');
-        name = name.trim();
+        name = normalizeNameOrVersion(name);
+        version = normalizeNameOrVersion(version);
 
         // @ts-ignore
         return new TypescriptScipSymbol(`scip-python python ${name} ${version} `);
     }
+}
+
+// See https://github.com/sourcegraph/scip/blob/main/scip.proto#L118-L121
+function normalizeNameOrVersion(s: string): string {
+    if (s === '') {
+        return '.';
+    }
+    if (s.indexOf(' ') === -1) {
+        return s;
+    }
+    return s.replace(/ /g, '  ');
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/scip-python/issues/92