### PR TITLE
test: Allow different package names and versions for subfolders

### DIFF
--- a/packages/pyright-scip/snapshots/input/odd_pkg_name_1/main.py
+++ b/packages/pyright-scip/snapshots/input/odd_pkg_name_1/main.py
@@ -1,0 +1,4 @@
+def main():
+    pass
+
+main()

--- a/packages/pyright-scip/snapshots/output/odd_pkg_name_1/main.py
+++ b/packages/pyright-scip/snapshots/output/odd_pkg_name_1/main.py
@@ -1,0 +1,13 @@
+# < definition scip-python python package with space 0.1 main/__init__:
+#documentation (module) main
+
+def main():
+#   ^^^^ definition  package with space 0.1 main/main().
+#   documentation ```python
+#               > def main(): # -> None:
+#               > ```
+    pass
+
+main()
+#^^^ reference  package with space 0.1 main/main().
+

--- a/packages/pyright-scip/snapshots/packageInfo.json
+++ b/packages/pyright-scip/snapshots/packageInfo.json
@@ -1,0 +1,12 @@
+{
+  "default": {
+    "name": "snapshot-util",
+    "version": "0.1"
+  },
+  "special": {
+    "odd_pkg_name_1": {
+      "name": "package with space",
+      "version": "0.1"
+    }
+  }
+}

--- a/packages/pyright-scip/test/test-main.ts
+++ b/packages/pyright-scip/test/test-main.ts
@@ -5,9 +5,18 @@ import * as fs from 'fs';
 function testMain(mode: 'check' | 'update'): void {
     const nodePath = process.argv[0];
     // Returns list of subdir names, not absolute paths.
-    const subdirNames = fs.readdirSync('./snapshots/input');
+    const inputDir = path.join('.', 'snapshots', 'input');
+    const subdirNames = fs.readdirSync(inputDir);
     for (const subdirName of subdirNames) {
-        console.assert(subdirName.includes('/') === false);
+        console.assert(path.dirname(subdirName) === '');
+        const projectInfoPath = path.join(inputDir, subdirName, 'project-info.json');
+        let projectName = 'snapshot-util';
+        let projectVersion = '0.1';
+        if (fs.existsSync(projectInfoPath)) {
+            const projectInfo = JSON.parse(fs.readFileSync(projectInfoPath).toString());
+            projectName = projectInfo['name'];
+            projectVersion = projectInfo['version'];
+        }
         const argv = [
             nodePath,
             path.resolve('./index.js'),
@@ -17,9 +26,9 @@ function testMain(mode: 'check' | 'update'): void {
             'snapshots/testEnv.json',
             '--quiet',
             '--project-name',
-            'snapshot-util',
+            projectName,
             '--project-version',
-            '0.1',
+            projectVersion,
             '--only',
             subdirName,
         ];

--- a/packages/pyright-scip/test/test-main.ts
+++ b/packages/pyright-scip/test/test-main.ts
@@ -1,25 +1,33 @@
 import { main } from '../src/main-impl';
 import * as path from 'path';
+import * as fs from 'fs';
 
 function testMain(mode: 'check' | 'update'): void {
     const nodePath = process.argv[0];
-    const argv = [
-        nodePath,
-        path.resolve('./index.js'),
-        'snapshot-dir',
-        './snapshots',
-        '--environment',
-        'snapshots/testEnv.json',
-        '--quiet',
-        '--project-name',
-        'snapshot-util',
-        '--project-version',
-        '0.1',
-    ];
-    if (mode === 'check') {
-        argv.push('--check');
+    // Returns list of subdir names, not absolute paths.
+    const subdirNames = fs.readdirSync('./snapshots/input');
+    for (const subdirName of subdirNames) {
+        console.assert(subdirName.includes('/') === false);
+        const argv = [
+            nodePath,
+            path.resolve('./index.js'),
+            'snapshot-dir',
+            './snapshots',
+            '--environment',
+            'snapshots/testEnv.json',
+            '--quiet',
+            '--project-name',
+            'snapshot-util',
+            '--project-version',
+            '0.1',
+            '--only',
+            subdirName,
+        ];
+        if (mode === 'check') {
+            argv.push('--check');
+        }
+        main(argv);
     }
-    main(argv);
 }
 
 if (process.argv.indexOf('--check') !== -1) {

--- a/packages/pyright-scip/test/test-main.ts
+++ b/packages/pyright-scip/test/test-main.ts
@@ -7,15 +7,15 @@ function testMain(mode: 'check' | 'update'): void {
     // Returns list of subdir names, not absolute paths.
     const inputDir = path.join('.', 'snapshots', 'input');
     const subdirNames = fs.readdirSync(inputDir);
+    const packageInfoPath = path.join('.', 'snapshots', 'packageInfo.json');
+    const packageInfo = JSON.parse(fs.readFileSync(packageInfoPath, 'utf8'));
     for (const subdirName of subdirNames) {
-        console.assert(path.dirname(subdirName) === '');
-        const projectInfoPath = path.join(inputDir, subdirName, 'project-info.json');
-        let projectName = 'snapshot-util';
-        let projectVersion = '0.1';
-        if (fs.existsSync(projectInfoPath)) {
-            const projectInfo = JSON.parse(fs.readFileSync(projectInfoPath).toString());
-            projectName = projectInfo['name'];
-            projectVersion = projectInfo['version'];
+        console.assert(path.dirname(subdirName) === '.');
+        let projectName = packageInfo['default']['name'];
+        let projectVersion = packageInfo['default']['version'];
+        if (subdirName in packageInfo['special']) {
+            projectName = packageInfo['special'][subdirName]['name'];
+            projectVersion = packageInfo['special'][subdirName]['version'];
         }
         const argv = [
             nodePath,

--- a/packages/pyright-scip/test/test-main.ts
+++ b/packages/pyright-scip/test/test-main.ts
@@ -4,13 +4,14 @@ import * as fs from 'fs';
 
 function testMain(mode: 'check' | 'update'): void {
     const nodePath = process.argv[0];
+    const startCwd = process.cwd();
     // Returns list of subdir names, not absolute paths.
     const inputDir = path.join('.', 'snapshots', 'input');
     const subdirNames = fs.readdirSync(inputDir);
     const packageInfoPath = path.join('.', 'snapshots', 'packageInfo.json');
     const packageInfo = JSON.parse(fs.readFileSync(packageInfoPath, 'utf8'));
     for (const subdirName of subdirNames) {
-        console.assert(path.dirname(subdirName) === '.');
+        console.assert(!subdirName.includes(path.sep));
         let projectName = packageInfo['default']['name'];
         let projectVersion = packageInfo['default']['version'];
         if (subdirName in packageInfo['special']) {
@@ -36,6 +37,8 @@ function testMain(mode: 'check' | 'update'): void {
             argv.push('--check');
         }
         main(argv);
+        // main changes the working directory; reset it.
+        process.chdir(startCwd);
     }
 }
 


### PR DESCRIPTION
We add a separate JSON file which tracks the project names and versions.
This makes it easy to add tests with unusual project names and versions,
to make sure we're handling those correctly end-to-end.