### PR TITLE
refactor: Remove redundant workspaceRoot field

### DIFF
--- a/packages/pyright-scip/src/indexer.ts
+++ b/packages/pyright-scip/src/indexer.ts
@@ -231,7 +231,7 @@ export class Indexer {
         if (this.scipConfig.targetOnly && this.scipConfig.targetOnly !== '') {
             return this.scipConfig.targetOnly;
         } else {
-            return this.scipConfig.workspaceRoot;
+            return this.scipConfig.projectRoot;
         }
     }
 }

--- a/packages/pyright-scip/src/lib.ts
+++ b/packages/pyright-scip/src/lib.ts
@@ -14,8 +14,6 @@ export interface ScipConfig extends IndexOptions {
      *
      * All `Document.relative_path` fields will be relative paths to this directory.
      */
-    workspaceRoot: string;
-
     projectRoot: string;
 
     infer: { projectVersionFromCommit: boolean };

--- a/packages/pyright-scip/src/main-impl.ts
+++ b/packages/pyright-scip/src/main-impl.ts
@@ -16,12 +16,11 @@ function indexAction(options: IndexOptions): void {
         setShowProgressRateLimit(options.showProgressRateLimit);
     }
 
-    const workspaceRoot = options.cwd;
+    const projectRoot = options.cwd;
     const snapshotDir = options.snapshotDir;
     const environment = options.environment;
 
-    const projectRoot = workspaceRoot;
-    process.chdir(workspaceRoot);
+    process.chdir(projectRoot);
 
     const outputFile = path.join(projectRoot, options.output);
     const output = fs.openSync(outputFile, 'w');
@@ -29,7 +28,6 @@ function indexAction(options: IndexOptions): void {
     try {
         let indexer = new Indexer({
             ...options,
-            workspaceRoot,
             projectRoot,
             environment,
             infer: { projectVersionFromCommit: true },
@@ -106,7 +104,6 @@ function snapshotAction(snapshotRoot: string, options: SnapshotOptions): void {
         if (options.index) {
             let indexer = new Indexer({
                 ...options,
-                workspaceRoot: projectRoot,
                 projectRoot,
                 environment,
                 infer: { projectVersionFromCommit: false },


### PR DESCRIPTION
We already track a projectRoot field which is the same.

No functional change.
