### PR TITLE
cleanup: Remove --snapshot-dir flag

### DIFF
--- a/packages/pyright-scip/src/MainCommand.ts
+++ b/packages/pyright-scip/src/MainCommand.ts
@@ -5,7 +5,6 @@ export interface IndexOptions {
     projectName: string;
     projectVersion: string;
     projectNamespace?: string;
-    snapshotDir: string;
     environment?: string;
     dev: boolean;
     output: string;
@@ -65,7 +64,6 @@ export function mainCommand(
         .option('--cwd <path>', 'working directory for executing scip-python', process.cwd())
         .option('--target-only <path>', 'limit analysis to the following path')
         .option('--output <path>', 'path to the output file', DEFAULT_OUTPUT_FILE)
-        .option('--snapshot-dir <path>', 'the directory to output a snapshot of the SCIP dump')
         .option('--quiet', 'run without logging and status information', false)
         .option(
             '--show-progress-rate-limit <limit>',

--- a/packages/pyright-scip/src/main-impl.ts
+++ b/packages/pyright-scip/src/main-impl.ts
@@ -17,7 +17,6 @@ function indexAction(options: IndexOptions): void {
     }
 
     const projectRoot = options.cwd;
-    const snapshotDir = options.snapshotDir;
     const environment = options.environment;
 
     const originalWorkdir = process.cwd();
@@ -50,25 +49,6 @@ function indexAction(options: IndexOptions): void {
     }
 
     fs.close(output);
-
-    if (snapshotDir) {
-        sendStatus(`Writing snapshot from index: ${outputFile}`);
-
-        const scipIndex = scip.Index.deserializeBinary(fs.readFileSync(outputFile));
-        for (const doc of scipIndex.documents) {
-            if (doc.relative_path.startsWith('..')) {
-                console.log('Skipping Doc:', doc.relative_path);
-                continue;
-            }
-
-            const inputPath = path.join(projectRoot, doc.relative_path);
-            const input = Input.fromFile(inputPath);
-            const obtained = formatSnapshot(input, doc, scipIndex.external_symbols);
-            const relativeToInputDirectory = path.relative(projectRoot, inputPath);
-            const outputPath = path.resolve(snapshotDir, relativeToInputDirectory);
-            writeSnapshot(outputPath, obtained);
-        }
-    }
 
     process.chdir(originalWorkdir);
 }


### PR DESCRIPTION
It is superseded by the snapshot-dir subcommand.
