### PR TITLE
refactor: Reuse indexAction in snapshotAction

### DIFF
--- a/packages/pyright-scip/src/MainCommand.ts
+++ b/packages/pyright-scip/src/MainCommand.ts
@@ -10,6 +10,7 @@ export interface IndexOptions {
     output: string;
     cwd: string;
     targetOnly?: string;
+    infer?: { projectVersionFromCommit: boolean };
 
     // Progress reporting configuration
     quiet: boolean;

--- a/packages/pyright-scip/test/test-main.ts
+++ b/packages/pyright-scip/test/test-main.ts
@@ -32,7 +32,7 @@ function testMain(mode: 'check' | 'update'): void {
             projectVersion,
             '--only',
             subdirName,
-        ];
+        ]; // FIXME: This should pass with a --dev flag
         if (mode === 'check') {
             argv.push('--check');
         }


### PR DESCRIPTION
This avoids having two different code paths creating an Indexer
object, and dealing with more path normalization.