### PR TITLE
fix: Allow 10MB buffer in `pipBulkShow`

### DIFF
--- a/packages/pyright-scip/src/virtualenv/environment.ts
+++ b/packages/pyright-scip/src/virtualenv/environment.ts
@@ -35,7 +35,7 @@ function pipList(): PipInformation[] {
 function pipBulkShow(names: string[]): string[] {
     // TODO: This probably breaks with enough names. Should batch them into 512 or whatever the max for bash would be
     return child_process
-        .execSync(`${getPipCommand()} show -f ${names.join(' ')}`)
+        .execSync(`${getPipCommand()} show -f ${names.join(' ')}`, { maxBuffer: 1024 * 1024 * 10 })
         .toString()
         .split('\n---');
 }


### PR DESCRIPTION
It indeed breaks with enough names. I think allowing 10MB buffer should be enough and also not break the clients machine.