### PR TITLE
refactor: building of docker images is more flexible

### DIFF
--- a/.github/workflows/scip-docker.yml
+++ b/.github/workflows/scip-docker.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/**'
-      - 'Dockerfile.autoindex'
+      - 'Dockerfile'
 
 jobs:
   build-image:
@@ -41,7 +41,7 @@ jobs:
         id: docker_build_autoindex
         uses: docker/build-push-action@v4
         with:
-          file: Dockerfile.autoindex
+          file: Dockerfile
           push: false
           tags: |
             sourcegraph/scip-python:test

--- a/.github/workflows/scip-release.yml
+++ b/.github/workflows/scip-release.yml
@@ -5,33 +5,96 @@ on:
     tags:
       - v*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  release-image:
+  publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: docker/setup-buildx-action@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '16'
-          registry-url: 'https://registry.npmjs.org'
-      - run: npm install
-      - run: cd ./packages/pyright-scip/ && npm install && npm run build
-      - run: cd ./packages/pyright-scip/ && npm publish --access public
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
+          node-version: 16
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+      - run: npm ci && npm run build
+        working-directory: ./packages/pyright-scip/
+
+      - if: ${{ env.NODE_AUTH_TOKEN }}
+        run: npm publish --access public
+        working-directory: ./packages/pyright-scip/
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  docker:
+    needs: publish
+    strategy:
+      fail-fast: false
+      matrix:
+        version_debian: [bookworm]
+        version_python: ['3.10']
+        version_node: ['16']
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+      # Permissions used for artifact attestation.
+      attestations: write
+      id-token: write
+
+    steps:
+      - uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Build and push
-        id: docker_build_autoindex
-        uses: docker/build-push-action@v4
+          registry: ${{ vars.REGISTRY || 'docker.io' }}
+          username: ${{ secrets.DOCKER_USERNAME || github.actor }}
+          password: ${{ secrets.DOCKER_PASSWORD || secrets.GITHUB_TOKEN }}
+
+      # Use QEMU and Buildx so we can build for multiple platforms.
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Generate image tags
+        id: meta
+        uses: docker/metadata-action@v5
         with:
-          file: Dockerfile.autoindex
-          push: true
+          images: ${{ vars.REGISTRY || 'docker.io' }}/${{ github.repository }}
+          flavor: |
+            latest=true
+          # NOTE: The autoindex tag seems to be legacy and overlaps fully with latest, dropping it might be breaking change.
           tags: |
-            sourcegraph/scip-python:autoindex
-            sourcegraph/scip-python:latest
-            sourcegraph/scip-python:${{ github.ref_name }}
+            type=sha,
+            type=schedule
+            type=raw,value=autoindex
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build and release image
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          cache-from: type=gha,scope=docker-${{ matrix.version_debian}}-${{ matrix.version_python}}-${{ matrix.version_node }}
+          cache-to: type=gha,mode=max,scope=docker-${{ matrix.version_debian}}-${{ matrix.version_python}}-${{ matrix.version_node }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          build-args: |-
+            VERSION_DEBIAN=${{ matrix.version_debian }}
+            VERSION_PYTHON=${{ matrix.version_python }}
+            VERSION_NODE=${{ matrix.version_node }}
+            VERSION_SCIP_PYTHON=${{ github.ref_name }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ vars.REGISTRY || 'docker.io' }}/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
         "editor.formatOnSave": true
     },
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
+        "source.fixAll.eslint": "explicit"
     },
     "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+ARG VERSION_DEBIAN=bookworm
+
+ARG VERSION_NODE=16
+ARG VERSION_PYTHON=3.10
+
+ARG VERSION_SCIP_PYTHON=v0.6.0
+
+FROM node:$VERSION_NODE-$VERSION_DEBIAN-slim as technology-node
+FROM python:$VERSION_PYTHON-slim-$VERSION_DEBIAN as technology-python
+
+FROM buildpack-deps:$VERSION_DEBIAN as base
+
+COPY --link --from=technology-node /usr/local /usr/local
+COPY --link --from=technology-python /usr/local /usr/local
+
+# NOTE: ldconfig is needed for Python to understand where shared libraries are.
+RUN ldconfig \
+    # We remove pre-installed yarn and enable corepack.
+    && rm -rf /usr/local/bin/yarn* \
+    && corepack enable \
+    # NOTE: Smoke tests while having as little side effects as possible.
+    && node --version \
+    && yarn --version \
+    && npm --logs-max=0 --version \
+    && PYTHONDONTWRITEBYTECODE=1 python3 --version \
+    && pip --version
+
+FROM base AS release
+
+ARG VERSION_SCIP_PYTHON
+
+# Install dependencies
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    bash \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install packages
+RUN npm install -g @sourcegraph/scip-python@$VERSION_SCIP_PYTHON @sourcegraph/src
+
+ENTRYPOINT [ "scip-python" ]

--- a/Dockerfile.autoindex
+++ b/Dockerfile.autoindex
@@ -1,6 +1,0 @@
-FROM nikolaik/python-nodejs:python3.10-nodejs16-alpine@sha256:fcbc543f7d4016679e2e6e8ec6345170f33426103dca9153068caaa9490d2fdd
-
-RUN apk add --no-cache git bash curl
-RUN npm install -g @sourcegraph/scip-python @sourcegraph/src
-
-CMD ["/bin/sh"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ $ # Install scip-python
 $ npm install -g @sourcegraph/scip-python
 ```
 
-scip-python requires Node v16 or newer. See the [Dockerfile](https://github.com/sourcegraph/scip-python/blob/scip/Dockerfile.autoindex) for an exact SHA that is tested.
+scip-python requires Node v16 or newer. See the [Dockerfile](https://github.com/sourcegraph/scip-python/blob/scip/Dockerfile) for an exact SHA that is tested.
 
 scip-python uses `pip` to attempt to determine the versions and names of the packages available in your environment. If you do not use pip to install the packages, you can instead use the `--environment` flag to supply a list of packages to use as the environment. This will skip any calls out to pip to determine the state of your env. See [Environment](##-environment) for more information.
 


### PR DESCRIPTION
This implements #146.

During the refactor I also modernized the build pipeline and Dockerfile with caching, steps, etc. I also use a trick to easily merge base images like node and python into a single image without using something like nikolaik/python-nodejs. However, I did use debian for this as it is more broadly supported on docker images.

I took the liberty to remove the `.autoindex` suffix from the Dockerfile. However, I did not remove this from the generated docker tags to avoid any breaking changes. That said, it fully overlaps with `latest` so it could be removed.

Finally, I did the build step using a matrix so in theory different version could be build. Maybe this is early-optimization but o well.

Before this is merged, feel free to use `ghcr.io/codean-io/scip-python` as your SCIP image if you need the ARM support.