### PR TITLE
Fix GitHub/GitLab brand capitalization

### DIFF
--- a/docs/_navbar.md
+++ b/docs/_navbar.md
@@ -1,1 +1,1 @@
-[Github Site](https://github.com/Microsoft/pyright)
+[GitHub Site](https://github.com/Microsoft/pyright)


### PR DESCRIPTION
This change ensures consistent capitalization of the GitHub and GitLab brand names in Markdown documentation.

[_Created by Sourcegraph batch change `sqs/capitalize-brands-correctly`._](https://sourcegraph.sourcegraph.com/users/sqs/batch-changes/capitalize-brands-correctly)