### PR TITLE
Fix issues with parsing 3.11 Python syntaxes

### DIFF
--- a/packages/pyright-scip/src/treeVisitor.ts
+++ b/packages/pyright-scip/src/treeVisitor.ts
@@ -377,7 +377,10 @@ export class TreeVisitor extends ParseTreeWalker {
                 continue;
             }
 
-            let decl = parentMethodType.details.declaration!;
+            let decl = parentMethodType.details.declaration;
+            if (!decl || !decl.node) {
+                continue;
+            }
             let symbol = this.typeToSymbol(decl.node.name, decl.node, parentMethodType);
             relationshipMap.set(
                 symbol.value,
@@ -1055,6 +1058,9 @@ export class TreeVisitor extends ParseTreeWalker {
                 if (moduleName === 'builtins') {
                     return Symbols.makeModule(this.stdlibPackage, 'builtins');
                 } else {
+                    if (!pythonPackage) {
+                        return ScipSymbol.local(this.counter.next());
+                    }
                     return Symbols.makeModule(pythonPackage, moduleName);
                 }
             }
@@ -1128,7 +1134,10 @@ export class TreeVisitor extends ParseTreeWalker {
                                 const bound = typeVar.details.boundType! as ClassType;
 
                                 return this.getSymbolOnce(node, () => {
-                                    const pythonPackage = this.getPackageInfo(node, bound.details.moduleName)!;
+                                    const pythonPackage = this.getPackageInfo(node, bound.details.moduleName);
+                                    if (!pythonPackage) {
+                                        return ScipSymbol.local(this.counter.next());
+                                    }
                                     let symbol = Symbols.makeTerm(
                                         Symbols.makeType(
                                             Symbols.makeModule(pythonPackage, bound.details.moduleName),
@@ -1340,10 +1349,16 @@ export class TreeVisitor extends ParseTreeWalker {
 
                 return ScipSymbol.local(this.counter.next());
             } else {
+                if (!pythonPackage) {
+                    return ScipSymbol.local(this.counter.next());
+                }
                 return Symbols.makeMethod(Symbols.makeModule(pythonPackage, typeObj.details.moduleName), node.value);
             }
         } else if (Types.isClass(typeObj)) {
-            const pythonPackage = this.getPackageInfo(node, typeObj.details.moduleName)!;
+            const pythonPackage = this.getPackageInfo(node, typeObj.details.moduleName);
+            if (!pythonPackage) {
+                return ScipSymbol.local(this.counter.next());
+            }
             return Symbols.makeClass(pythonPackage, typeObj.details.moduleName, node.value);
         } else if (Types.isClassInstance(typeObj)) {
             typeObj = typeObj as ClassType;
@@ -1352,7 +1367,10 @@ export class TreeVisitor extends ParseTreeWalker {
         } else if (Types.isTypeVar(typeObj)) {
             throw 'typevar';
         } else if (Types.isModule(typeObj)) {
-            const pythonPackage = this.getPackageInfo(node, typeObj.moduleName)!;
+            const pythonPackage = this.getPackageInfo(node, typeObj.moduleName);
+            if (!pythonPackage) {
+                return ScipSymbol.local(this.counter.next());
+            }
             return Symbols.makeModuleInit(pythonPackage, typeObj.moduleName);
         } else if (Types.isOverloadedFunction(typeObj)) {
             if (!typeObj.overloads) {


### PR DESCRIPTION
  # Summary of Fixed Issues

  1. Original Error in getFunctionRelationships: Fixed undefined decl when accessing parentMethodType.details.declaration.node
  2. Multiple errors in makeModule calls: Fixed undefined pythonPackage parameters passed to makeModule and makeModuleInit functions

  # Key Fixes Applied

  1. treeVisitor.ts:380-384: Added null check for parentMethodType.details.declaration
  2. treeVisitor.ts:1061-1065: Added null check for pythonPackage before calling makeModule
  3. treeVisitor.ts:1137-1140: Added null check for getPackageInfo result
  4. treeVisitor.ts:1352-1356: Added null check for pythonPackage before calling makeModule
  5. treeVisitor.ts:1358-1362: Added null check for getPackageInfo result
  6. treeVisitor.ts:1370-1374: Added null check for getPackageInfo result