### PR TITLE
fix: Limit macOS fix to pyright-scip-side code changes

### DIFF
--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -293,9 +293,7 @@ export class Program {
         }
 
         // Add the new files. Only the new items will be added.
-        // Normalize paths to ensure consistency with other code paths.
-        const normalizedFilePaths = filePaths.map(path => normalizePathCase(this._fs, path));
-        this.addTrackedFiles(normalizedFilePaths);
+        this.addTrackedFiles(filePaths);
 
         return this._removeUnneededFiles();
     }

--- a/packages/pyright-scip/src/indexer.ts
+++ b/packages/pyright-scip/src/indexer.ts
@@ -9,6 +9,7 @@ import { createFromRealFileSystem } from 'pyright-internal/common/realFileSystem
 import { ConfigOptions } from 'pyright-internal/common/configOptions';
 import { TreeVisitor } from './treeVisitor';
 import { FullAccessHost } from 'pyright-internal/common/fullAccessHost';
+import { normalizePathCase } from 'pyright-internal/common/pathUtils';
 import * as url from 'url';
 import { ScipConfig } from './lib';
 import { SourceFile } from 'pyright-internal/analyzer/sourceFile';
@@ -122,7 +123,9 @@ export class Indexer {
         this.importResolver = new ImportResolver(fs, this.pyrightConfig, host);
 
         this.program = new Program(this.importResolver, this.pyrightConfig);
-        this.program.setTrackedFiles([...this.projectFiles]);
+        // Normalize paths to ensure consistency with other code paths.
+        const normalizedProjectFiles = [...this.projectFiles].map((path: string) => normalizePathCase(fs, path));
+        this.program.setTrackedFiles(normalizedProjectFiles);
 
         if (scipConfig.projectNamespace) {
             setProjectNamespace(scipConfig.projectName, this.scipConfig.projectNamespace!);


### PR DESCRIPTION
In PR https://github.com/sourcegraph/scip-python/pull/177, we added
normalization logic inside `setTrackedFiles`.

However, it seems like the other file tracking already must be
taking care of passing normalized paths as necessary (hopefully?).

In order to minimize the diff size, I'm moving the normalization
to the call-site of `setTrackedFiles` inside the pyright-scip folder.
We want to do a merge of upstream changes sooner rather than later,
so it'd be good to reduce the diff.