### PR TITLE
fix: Properly enable source maps in all modes

### DIFF
--- a/packages/pyright-scip/index.js
+++ b/packages/pyright-scip/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --enable-source-maps
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
 

--- a/packages/pyright-scip/webpack.config.js
+++ b/packages/pyright-scip/webpack.config.js
@@ -31,7 +31,9 @@ module.exports = (_, { mode }) => {
                 mode === 'development' ? '../[resource-path]' : monorepoResourceNameMapper('scip-python'),
             clean: true,
         },
-        devtool: mode === 'development' ? 'inline-source-map' : 'nosources-source-map',
+        // NOTE: Other settings for this value seem to show stack traces
+        // with mangled symbols that are not useful. Modify with care.
+        devtool: 'source-map',
         stats: {
             all: false,
             errors: true,


### PR DESCRIPTION
We need to pass `--enable-source-maps` when launching `node`,
because Node will not use source maps (even if present) by default.

Additionally, let's avoid the divergence in settings across development
and production.