### PR TITLE
Prepare for scip-python 0.6.1 release

### DIFF
--- a/packages/pyright-scip/CONTRIBUTING.md
+++ b/packages/pyright-scip/CONTRIBUTING.md
@@ -64,7 +64,7 @@ in `packages/pyright-scip` which can be invoked with Node
 to index a test project.
 
 ```
-node --enable-source-maps ./index.js <other args>
+node ./index.js <other args>
 ```
 
 ### Running tests
@@ -72,8 +72,6 @@ node --enable-source-maps ./index.js <other args>
 ```bash
 npm run check-snapshots
 ```
-
-**WARNING:** At the moment, there are [some known test failures on macOS](https://github.com/sourcegraph/scip-python/issues/91).
 
 Using a different Python version other than the one specified
 in `.tool-versions` may also lead to errors.

--- a/packages/pyright-scip/package-lock.json
+++ b/packages/pyright-scip/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sourcegraph/scip-python",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sourcegraph/scip-python",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/packages/pyright-scip/package.json
+++ b/packages/pyright-scip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/scip-python",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "SCIP indexer for Python",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Updates some docs based on recent changes,
and updates package.json so that we can
create a new release where we get meaningful
stack traces on errors.