### PR TITLE
fix: Make tests more robust & fix path-handling bugs on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 
+# Editor files
+.idea/
+
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 

--- a/packages/pyright-internal/src/analyzer/program.ts
+++ b/packages/pyright-internal/src/analyzer/program.ts
@@ -331,7 +331,15 @@ export class Program {
 
     addTrackedFile(filePath: string, isThirdPartyImport = false, isInPyTypedPackage = false): SourceFile {
         let sourceFileInfo = this.getSourceFileInfo(filePath);
-        const importName = this._getImportNameForFile(filePath);
+        let importName = this._getImportNameForFile(filePath);
+        // HACK(scip-python): When adding tracked files for imports, we end up passing
+        // normalized paths as the argument. However, _getImportNameForFile seemingly
+        // needs a non-normalized path, which cannot be recovered directly from a
+        // normalized path. However, in practice, the non-normalized path seems to
+        // be stored on the sourceFileInfo, so attempt to use that instead.
+        if (importName === '' && sourceFileInfo) {
+            importName = this._getImportNameForFile(sourceFileInfo.sourceFile.getFilePath());
+        }
 
         if (sourceFileInfo) {
             // The module name may have changed based on updates to the

--- a/packages/pyright-scip/CONTRIBUTING.md
+++ b/packages/pyright-scip/CONTRIBUTING.md
@@ -73,8 +73,31 @@ node ./index.js <other args>
 npm run check-snapshots
 ```
 
+#### Filter specific snapshot tests
+
+Use the `--filter-tests` flag to run only specific snapshot tests:
+```bash
+# Using npm scripts (note the -- to pass arguments)
+npm run check-snapshots -- --filter-tests test1,test2,test3
+```
+
+Available snapshot tests can be found in `snapshots/input/`.
+
 Using a different Python version other than the one specified
 in `.tool-versions` may also lead to errors.
+
+## Making changes to Pyright internals
+
+When modifying code in the `pyright-internal` package:
+
+1. Keep changes minimal: Every change introduces a risk of
+   merge conflicts. Adding doc comments is fine, but avoid
+   changing functionality if possible. Instead of changing
+   access modifiers, prefer copying small functions into
+   scip-pyright logic.
+2. Use a `NOTE(scip-python):` prefix when adding comments to
+   make it clearer which comments were added by upstream
+   maintainers vs us.
 
 ## Publishing releases
 

--- a/packages/pyright-scip/src/assertions.ts
+++ b/packages/pyright-scip/src/assertions.ts
@@ -1,0 +1,130 @@
+import { normalizePathCase, isFileSystemCaseSensitive } from 'pyright-internal/common/pathUtils';
+import { PyrightFileSystem } from 'pyright-internal/pyrightFileSystem';
+import { createFromRealFileSystem } from 'pyright-internal/common/realFileSystem';
+
+export enum SeenCondition {
+    AlwaysFalse = 'always-false',
+    AlwaysTrue = 'always-true',
+    Mixed = 'mixed'
+}
+
+export class AssertionError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'AssertionError';
+    }
+}
+
+// Private global state - never export directly
+let _assertionFlags = {
+    pathNormalizationChecks: false,
+    otherChecks: false
+};
+let _context = '';
+const _sometimesResults = new Map<string, Map<string, SeenCondition>>();
+
+export function setGlobalAssertionFlags(pathNormalizationChecks: boolean, otherChecks: boolean): void {
+    _assertionFlags.pathNormalizationChecks = pathNormalizationChecks;
+    _assertionFlags.otherChecks = otherChecks;
+}
+
+export function setGlobalContext(context: string): void {
+    _context = context;
+}
+
+// Internal implementation functions
+function assertAlwaysImpl(enableFlag: boolean, check: () => boolean, message: () => string): void {
+    if (!enableFlag) return;
+    
+    if (!check()) {
+        throw new AssertionError(message());
+    }
+}
+
+function assertSometimesImpl(enableFlag: boolean, check: () => boolean, key: string): void {
+    if (!enableFlag) return;
+    
+    const ctx = _context;
+    if (ctx === '') {
+        throw new AssertionError('Context must be set before calling assertSometimes');
+    }
+    
+    let ctxMap = _sometimesResults.get(key);
+    if (!ctxMap) {
+        ctxMap = new Map();
+        _sometimesResults.set(key, ctxMap);
+    }
+    
+    const result = check() ? SeenCondition.AlwaysTrue : SeenCondition.AlwaysFalse;
+    const prev = ctxMap.get(ctx);
+    
+    if (prev === undefined) {
+        ctxMap.set(ctx, result);
+    } else if (prev !== result) {
+        ctxMap.set(ctx, SeenCondition.Mixed);
+    }
+}
+
+const _fs = new PyrightFileSystem(createFromRealFileSystem());
+
+export function assertAlways(check: () => boolean, message: () => string): void {
+    assertAlwaysImpl(_assertionFlags.otherChecks, check, message);
+}
+
+export function assertSometimes(check: () => boolean, key: string): void {
+    assertSometimesImpl(_assertionFlags.otherChecks, check, key);
+}
+
+export function assertNeverNormalized(path: string): void {
+    const normalized = normalizePathCase(_fs, path);
+    assertAlwaysImpl(
+        _assertionFlags.pathNormalizationChecks,
+        () => normalized !== path,
+        () => `Path should not be normalized but was: ${path}`
+    );
+}
+
+export function assertAlwaysNormalized(path: string): void {
+    const normalized = normalizePathCase(_fs, path);
+    assertAlwaysImpl(
+        _assertionFlags.pathNormalizationChecks,
+        () => normalized === path,
+        () => `Path should be normalized but was not: ${path} -> ${normalized}`
+    );
+}
+
+export function assertSometimesNormalized(path: string, key: string): void {
+    const normalized = normalizePathCase(_fs, path);
+    assertSometimesImpl(
+        _assertionFlags.pathNormalizationChecks,
+        () => normalized === path,
+        key
+    );
+}
+
+// Monoidal combination logic
+function combine(a: SeenCondition, b: SeenCondition): SeenCondition {
+    if (a === b) return a;
+    if (a === SeenCondition.Mixed || b === SeenCondition.Mixed) {
+        return SeenCondition.Mixed;
+    }
+    // AlwaysTrue + AlwaysFalse = Mixed
+    return SeenCondition.Mixed;
+}
+
+export function checkSometimesAssertions(): Map<string, SeenCondition> {
+    const summary = new Map<string, SeenCondition>();
+    
+    for (const [key, ctxMap] of _sometimesResults) {
+        let agg: SeenCondition | undefined;
+        for (const state of ctxMap.values()) {
+            agg = agg === undefined ? state : combine(agg, state);
+            if (agg === SeenCondition.Mixed) break;
+        }
+        if (agg !== undefined) {
+            summary.set(key, agg);
+        }
+    }
+    
+    return summary;
+}

--- a/packages/pyright-scip/src/config.ts
+++ b/packages/pyright-scip/src/config.ts
@@ -17,6 +17,7 @@ import {
 } from 'pyright-internal/common/pathUtils';
 import { PyrightFileSystem } from 'pyright-internal/pyrightFileSystem';
 import { ScipConfig } from './lib';
+import { sendStatus } from './status';
 
 const configFileNames = ['scip-pyrightconfig.json', 'pyrightconfig.json'];
 const pyprojectTomlName = 'pyproject.toml';
@@ -26,6 +27,8 @@ export class ScipPyrightConfig {
     _configFilePath: string | undefined;
     _configOptions: ConfigOptions;
 
+    // Use this for debug logging only. For sending user messages, use sendStatus.
+    // Some old code does not respect this.
     _console: Console = console;
     _typeCheckingMode = 'basic';
 
@@ -100,7 +103,7 @@ export class ScipPyrightConfig {
             if (configFilePath) {
                 projectRoot = getDirectoryPath(configFilePath);
             } else {
-                this._console.log(`No configuration file found.`);
+                sendStatus(`No configuration file found.`);
                 configFilePath = undefined;
             }
         }
@@ -115,9 +118,9 @@ export class ScipPyrightConfig {
 
             if (pyprojectFilePath) {
                 projectRoot = getDirectoryPath(pyprojectFilePath);
-                this._console.log(`pyproject.toml file found at ${projectRoot}.`);
+                sendStatus(`pyproject.toml file found at ${projectRoot}.`);
             } else {
-                this._console.log(`No pyproject.toml file found.`);
+                sendStatus(`No pyproject.toml file found.`);
             }
         }
 
@@ -180,7 +183,7 @@ export class ScipPyrightConfig {
             this._console.info(`Loading configuration file at ${configFilePath}`);
             configJsonObj = this._parseJsonConfigFile(configFilePath);
         } else if (pyprojectFilePath) {
-            this._console.info(`Loading pyproject.toml file at ${pyprojectFilePath}`);
+            sendStatus(`Loading pyproject.toml file at ${pyprojectFilePath}`);
             configJsonObj = this._parsePyprojectTomlFile(pyprojectFilePath);
         }
 

--- a/packages/pyright-scip/src/indexer.ts
+++ b/packages/pyright-scip/src/indexer.ts
@@ -117,15 +117,15 @@ export class Indexer {
             this.projectFiles = targetFiles;
         }
 
-        console.log('Total Project Files', this.projectFiles.size);
+        sendStatus(`Total Project Files ${this.projectFiles.size}`);
 
         const host = new FullAccessHost(fs);
         this.importResolver = new ImportResolver(fs, this.pyrightConfig, host);
 
         this.program = new Program(this.importResolver, this.pyrightConfig);
-        // Normalize paths to ensure consistency with other code paths.
-        const normalizedProjectFiles = [...this.projectFiles].map((path: string) => normalizePathCase(fs, path));
-        this.program.setTrackedFiles(normalizedProjectFiles);
+        // setTrackedFiles internally handles path normalization, so we don't normalize
+        // paths here.
+        this.program.setTrackedFiles([...this.projectFiles]);
 
         if (scipConfig.projectNamespace) {
             setProjectNamespace(scipConfig.projectName, this.scipConfig.projectNamespace!);
@@ -194,7 +194,9 @@ export class Indexer {
         let projectSourceFiles: SourceFile[] = [];
         withStatus('Index workspace and track project files', () => {
             this.program.indexWorkspace((filepath: string) => {
-                // Filter out filepaths not part of this project
+                // Do not index files outside the project because SCIP doesn't support it.
+                //
+                // Both filepath and this.scipConfig.projectRoot are NOT normalized.
                 if (filepath.indexOf(this.scipConfig.projectRoot) != 0) {
                     return;
                 }
@@ -204,6 +206,7 @@ export class Indexer {
 
                 let requestsImport = sourceFile.getImports();
                 requestsImport.forEach((entry) =>
+                    // entry.resolvedPaths are all normalized.
                     entry.resolvedPaths.forEach((value) => {
                         this.program.addTrackedFile(value, true, false);
                     })

--- a/packages/pyright-scip/src/lib.ts
+++ b/packages/pyright-scip/src/lib.ts
@@ -310,10 +310,10 @@ export function writeSnapshot(outputPath: string, obtained: string): void {
     fs.writeFileSync(outputPath, obtained, { flag: 'w' });
 }
 
-export function diffSnapshot(outputPath: string, obtained: string): void {
+export function diffSnapshot(outputPath: string, obtained: string): 'equal' | 'different' {
     let existing = fs.readFileSync(outputPath, { encoding: 'utf8' });
     if (obtained === existing) {
-        return;
+        return 'equal';
     }
 
     console.error(
@@ -326,7 +326,7 @@ export function diffSnapshot(outputPath: string, obtained: string): void {
             '(what the current code produces). Run the command "npm run update-snapshots" to accept the new behavior.'
         )
     );
-    exit(1);
+    return 'different';
 }
 
 function occurrencesByLine(a: scip.Occurrence, b: scip.Occurrence): number {

--- a/packages/pyright-scip/src/main-impl.ts
+++ b/packages/pyright-scip/src/main-impl.ts
@@ -10,7 +10,8 @@ import { sendStatus, setQuiet, setShowProgressRateLimit } from './status';
 import { Indexer } from './indexer';
 import { exit } from 'process';
 
-function indexAction(options: IndexOptions): void {
+
+export function indexAction(options: IndexOptions): void {
     setQuiet(options.quiet);
     if (options.showProgressRateLimit !== undefined) {
         setShowProgressRateLimit(options.showProgressRateLimit);
@@ -91,6 +92,8 @@ function snapshotAction(snapshotRoot: string, options: SnapshotOptions): void {
 
         const scipIndexPath = path.join(projectRoot, options.output);
         const scipIndex = scip.Index.deserializeBinary(fs.readFileSync(scipIndexPath));
+
+        let hasDiff = false;
         for (const doc of scipIndex.documents) {
             if (doc.relative_path.startsWith('..')) {
                 continue;
@@ -103,10 +106,14 @@ function snapshotAction(snapshotRoot: string, options: SnapshotOptions): void {
             const outputPath = path.resolve(outputDirectory, snapshotDir, relativeToInputDirectory);
 
             if (options.check) {
-                diffSnapshot(outputPath, obtained);
+                const diffResult = diffSnapshot(outputPath, obtained);
+                hasDiff = hasDiff || diffResult === 'different';
             } else {
                 writeSnapshot(outputPath, obtained);
             }
+        }
+        if (hasDiff) {
+            exit(1);
         }
     }
 }

--- a/packages/pyright-scip/src/test-runner.ts
+++ b/packages/pyright-scip/src/test-runner.ts
@@ -1,10 +1,11 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { join } from 'path';
+import { checkSometimesAssertions, SeenCondition } from './assertions';
 
 export interface TestFailure {
     testName: string;
-    type: 'empty-scip-index' | 'missing-output' | 'content-mismatch' | 'orphaned-output' | 'caught-exception';
+    type: 'empty-scip-index' | 'missing-output' | 'content-mismatch' | 'orphaned-output' | 'caught-exception' | 'sometimes-assertion';
     message: string;
 }
 
@@ -154,6 +155,20 @@ export class TestRunner {
                 }
                 reportResults(results);
                 return;
+            }
+        }
+
+        // Only check sometimes assertions when running all tests, not when filtering
+        if (!this.options.filterTests) {
+            const sometimesResults = checkSometimesAssertions();
+            for (const [key, state] of sometimesResults) {
+                if (state === SeenCondition.Mixed) continue; // success
+                
+                results.failed.push({
+                    testName: 'assertions',
+                    type: 'sometimes-assertion',
+                    message: `Assertion '${key}' was ${state} across all test contexts`
+                });
             }
         }
 

--- a/packages/pyright-scip/src/test-runner.ts
+++ b/packages/pyright-scip/src/test-runner.ts
@@ -1,0 +1,162 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { join } from 'path';
+
+export interface TestFailure {
+    testName: string;
+    type: 'empty-scip-index' | 'missing-output' | 'content-mismatch' | 'orphaned-output' | 'caught-exception';
+    message: string;
+}
+
+export interface ValidationResults {
+    passed: string[];
+    failed: TestFailure[];
+    skipped: string[];
+}
+
+export interface TestRunnerOptions {
+    snapshotRoot: string;
+    filterTests?: string;
+    failFast: boolean;
+    quiet: boolean;
+    mode: 'check' | 'update';
+}
+
+export interface SingleTestOptions {
+    check: boolean;
+    quiet: boolean;
+}
+
+function validateFilterTestNames(inputDirectory: string, filterTestNames: string[]): void {
+    const availableTests = fs.readdirSync(inputDirectory);
+    const missingTests = filterTestNames.filter(name => !availableTests.includes(name));
+    
+    if (missingTests.length > 0) {
+        console.error(`ERROR: The following test names were not found: ${missingTests.join(', ')}. Available tests: ${availableTests.join(', ')}`);
+        process.exit(1);
+    }
+}
+
+function handleOrphanedOutputs(inputTests: Set<string>, outputDirectory: string, mode: 'check' | 'update'): TestFailure[] {
+    if (!fs.existsSync(outputDirectory)) {
+        return [];
+    }
+    
+    const outputTests = fs.readdirSync(outputDirectory);
+    const orphanedOutputs: TestFailure[] = [];
+    
+    for (const outputTest of outputTests) {
+        if (inputTests.has(outputTest)) {
+            continue;
+        }
+        if (mode === 'update') {
+            const orphanedPath = path.join(outputDirectory, outputTest);
+            fs.rmSync(orphanedPath, { recursive: true, force: true });
+            console.log(`Delete output folder with no corresponding input folder: ${outputTest}`);
+            continue;
+        }
+        orphanedOutputs.push({
+            testName: outputTest,
+            type: 'orphaned-output',
+            message: `Output folder exists but no corresponding input folder found`
+        });
+    }
+    
+    return orphanedOutputs;
+}
+
+function reportResults(results: ValidationResults): void {
+    const totalTests = results.passed.length + results.failed.length + results.skipped.length;
+    console.assert(totalTests > 0, 'No tests found');
+    
+    for (const failure of results.failed) {
+        console.error(`FAIL [${failure.testName}]: ${failure.message}`);
+    }
+    
+    let summaryStr = `\n${results.passed.length}/${totalTests} tests passed, ${results.failed.length} failed`;
+    if (results.skipped.length > 0) {
+        summaryStr += `, ${results.skipped.length} skipped`;
+    }
+    console.log(summaryStr);
+
+    if (results.failed.length > 0) {
+        process.exit(1);
+    }
+}
+
+export class TestRunner {
+    constructor(private options: TestRunnerOptions) {}
+
+    runTests(
+        runSingleTest: (testName: string, inputDir: string, outputDir: string) => ValidationResults
+    ): void {
+        const inputDirectory = path.resolve(join(this.options.snapshotRoot, 'input'));
+        const outputDirectory = path.resolve(join(this.options.snapshotRoot, 'output'));
+
+        const results: ValidationResults = {
+            passed: [],
+            failed: [],
+            skipped: []
+        };
+
+        let snapshotDirectories = fs.readdirSync(inputDirectory);
+
+        const orphanedOutputs = handleOrphanedOutputs(new Set(snapshotDirectories), outputDirectory, this.options.mode);
+        if (orphanedOutputs.length > 0) {
+            results.failed.push(...orphanedOutputs);
+            if (this.options.failFast) {
+                reportResults(results);
+                return;
+            }
+        }
+
+        if (this.options.filterTests) {
+            const filterTestNames = this.options.filterTests.split(',').map(name => name.trim());
+            validateFilterTestNames(inputDirectory, filterTestNames);
+            snapshotDirectories = snapshotDirectories.filter(dir => filterTestNames.includes(dir));
+            if (snapshotDirectories.length === 0) {
+                console.error(`No tests found matching filter: ${this.options.filterTests}`);
+                process.exit(1);
+            }
+        }
+
+        for (let i = 0; i < snapshotDirectories.length; i++) {
+            const testName = snapshotDirectories[i];
+            if (!this.options.quiet) {
+                console.log(`--- Running snapshot test: ${testName} ---`);
+            }
+
+            let testResults: ValidationResults;
+            try {
+                testResults = runSingleTest(
+                    testName, 
+                    inputDirectory, 
+                    outputDirectory,
+                );
+            } catch (error) {
+                testResults = {
+                    passed: [],
+                    failed: [{
+                        testName,
+                        type: 'caught-exception',
+                        message: `Test runner failed: ${error}`
+                    }],
+                    skipped: []
+                };
+            }
+
+            results.passed.push(...testResults.passed);
+            results.failed.push(...testResults.failed);
+
+            if (this.options.failFast && testResults.failed.length > 0) {
+                for (let j = i + 1; j < snapshotDirectories.length; j++) {
+                    results.skipped.push(snapshotDirectories[j]);
+                }
+                reportResults(results);
+                return;
+            }
+        }
+
+        reportResults(results);
+    }
+}

--- a/packages/pyright-scip/src/treeVisitor.ts
+++ b/packages/pyright-scip/src/treeVisitor.ts
@@ -54,6 +54,10 @@ import { HoverResults } from 'pyright-internal/languageService/hoverProvider';
 import { convertDocStringToMarkdown } from 'pyright-internal/analyzer/docStringConversion';
 import { assert } from 'pyright-internal/common/debug';
 import { getClassFieldsRecursive } from 'pyright-internal/analyzer/typeUtils';
+import {createFromFileSystem} from "pyright-internal/tests/harness/vfs/factory";
+import {PyrightFileSystem} from "pyright-internal/pyrightFileSystem";
+import {createFromRealFileSystem} from "pyright-internal/common/realFileSystem";
+import {normalizePathCase} from "pyright-internal/common/pathUtils";
 
 //  Useful functions for later, but haven't gotten far enough yet to use them.
 //      extractParameterDocumentation
@@ -500,16 +504,26 @@ export class TreeVisitor extends ParseTreeWalker {
     override visitImportAs(node: ImportAsNode): boolean {
         const moduleName = _formatModuleName(node.module);
         const importInfo = getImportInfo(node.module);
+
         if (
             importInfo &&
             importInfo.resolvedPaths[0] &&
-            path.resolve(importInfo.resolvedPaths[0]).startsWith(this.cwd)
+            ((): boolean => {
+                // HACK(id: inconsistent-casing-of-resolved-paths):
+                // Sometimes the resolvedPath is normalized and sometimes it is not.
+                // If we remove one of the two checks below, existing tests start failing
+                // (aliased_import and nested_items tests). So do both checks.
+                const resolvedPath = path.resolve(importInfo.resolvedPaths[0])
+                return resolvedPath.startsWith(this.cwd) ||
+                    resolvedPath.startsWith(
+                        normalizePathCase(new PyrightFileSystem(createFromRealFileSystem()), this.cwd))
+            })()
         ) {
             const symbol = Symbols.makeModuleInit(this.projectPackage, moduleName);
+
             this.pushNewOccurrence(node.module, symbol);
         } else {
             const pythonPackage = this.moduleNameNodeToPythonPackage(node.module);
-
             if (pythonPackage) {
                 const symbol = Symbols.makeModuleInit(pythonPackage, moduleName);
                 this.pushNewOccurrence(node.module, symbol);
@@ -1417,6 +1431,10 @@ export class TreeVisitor extends ParseTreeWalker {
 
         // TODO: Should use files from the package to determine this -- should be able to do that quite easily.
         if (nodeFilePath.startsWith(this.cwd)) {
+            // NOTE: Unlike other code paths where we have
+            // HACK(id: inconsistent-casing-of-resolved-paths),
+            // here, nodeFilePath seems to never be normalized,
+            // so avoid a separate check.
             return this.projectPackage;
         }
 
@@ -1636,7 +1654,12 @@ export class TreeVisitor extends ParseTreeWalker {
         if (declPath && declPath.length !== 0) {
             const p = path.resolve(declPath);
 
-            if (p.startsWith(this.cwd)) {
+            // HACK(id: inconsistent-casing-of-resolved-paths):
+            // On a case-insensitive filesystem, p can sometimes be fully lowercased
+            // (e.g. see the nested_items test), and sometimes it may have uppercase
+            // characters (e.g. the unique test).
+            if (p.startsWith(this.cwd) ||
+                p.startsWith(normalizePathCase(new PyrightFileSystem(createFromRealFileSystem()), this.cwd))) {
                 return this.projectPackage;
             }
         }

--- a/packages/pyright-scip/src/treeVisitor.ts
+++ b/packages/pyright-scip/src/treeVisitor.ts
@@ -54,10 +54,10 @@ import { HoverResults } from 'pyright-internal/languageService/hoverProvider';
 import { convertDocStringToMarkdown } from 'pyright-internal/analyzer/docStringConversion';
 import { assert } from 'pyright-internal/common/debug';
 import { getClassFieldsRecursive } from 'pyright-internal/analyzer/typeUtils';
-import {createFromFileSystem} from "pyright-internal/tests/harness/vfs/factory";
-import {PyrightFileSystem} from "pyright-internal/pyrightFileSystem";
-import {createFromRealFileSystem} from "pyright-internal/common/realFileSystem";
-import {normalizePathCase} from "pyright-internal/common/pathUtils";
+import { PyrightFileSystem } from "pyright-internal/pyrightFileSystem";
+import { createFromRealFileSystem } from "pyright-internal/common/realFileSystem";
+import { normalizePathCase } from "pyright-internal/common/pathUtils";
+import { assertNeverNormalized, assertSometimesNormalized } from "./assertions";
 
 //  Useful functions for later, but haven't gotten far enough yet to use them.
 //      extractParameterDocumentation
@@ -514,6 +514,8 @@ export class TreeVisitor extends ParseTreeWalker {
                 // If we remove one of the two checks below, existing tests start failing
                 // (aliased_import and nested_items tests). So do both checks.
                 const resolvedPath = path.resolve(importInfo.resolvedPaths[0])
+                assertSometimesNormalized(resolvedPath, 'visitImportAs.resolvedPath')
+
                 return resolvedPath.startsWith(this.cwd) ||
                     resolvedPath.startsWith(
                         normalizePathCase(new PyrightFileSystem(createFromRealFileSystem()), this.cwd))
@@ -1430,11 +1432,13 @@ export class TreeVisitor extends ParseTreeWalker {
         const nodeFilePath = path.resolve(nodeFileInfo.filePath);
 
         // TODO: Should use files from the package to determine this -- should be able to do that quite easily.
+
+        // NOTE: Unlike other code paths where we have
+        // HACK(id: inconsistent-casing-of-resolved-paths),
+        // here, nodeFilePath seems to never be normalized,
+        // so avoid a separate check.
+        assertNeverNormalized(nodeFilePath);
         if (nodeFilePath.startsWith(this.cwd)) {
-            // NOTE: Unlike other code paths where we have
-            // HACK(id: inconsistent-casing-of-resolved-paths),
-            // here, nodeFilePath seems to never be normalized,
-            // so avoid a separate check.
             return this.projectPackage;
         }
 
@@ -1658,6 +1662,7 @@ export class TreeVisitor extends ParseTreeWalker {
             // On a case-insensitive filesystem, p can sometimes be fully lowercased
             // (e.g. see the nested_items test), and sometimes it may have uppercase
             // characters (e.g. the unique test).
+            assertSometimesNormalized(p, 'guessPackage.declPath.resolved');
             if (p.startsWith(this.cwd) ||
                 p.startsWith(normalizePathCase(new PyrightFileSystem(createFromRealFileSystem()), this.cwd))) {
                 return this.projectPackage;

--- a/packages/pyright-scip/test/test-main.ts
+++ b/packages/pyright-scip/test/test-main.ts
@@ -1,7 +1,185 @@
-import { main } from '../src/main-impl';
+import { main, indexAction } from '../src/main-impl';
+import { TestRunner, ValidationResults } from '../src/test-runner';
+import { scip } from '../src/scip';
+import { Input } from '../src/lsif-typescript/Input';
+import { formatSnapshot, writeSnapshot, diffSnapshot } from '../src/lib';
+import { SnapshotOptions } from '../src/MainCommand';
+import { join } from 'path';
 import * as path from 'path';
 import * as fs from 'fs';
 import { Indexer } from '../src/indexer';
+
+function createTempDirectory(outputDirectory: string, testName: string): string {
+    const tempPrefix = path.join(path.dirname(outputDirectory), `.tmp-${testName}-`);
+    return fs.mkdtempSync(tempPrefix);
+}
+
+function replaceFolder(tempDir: string, finalDir: string): void {
+    fs.rmSync(finalDir, { recursive: true, force: true });
+    fs.renameSync(tempDir, finalDir);
+}
+
+function cleanupTempDirectory(tempDir: string): void {
+    try {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch (error) {
+        console.warn(`Warning: Failed to cleanup temp directory ${tempDir}: ${error}`);
+    }
+}
+
+function validateOutputExists(outputDirectory: string, testName: string) {
+    const testOutputPath = path.join(outputDirectory, testName);
+    if (!fs.existsSync(testOutputPath)) {
+        return {
+            testName,
+            type: 'missing-output' as const,
+            message: `Expected output folder does not exist`
+        };
+    }
+    
+    return null;
+}
+
+function processSingleTest(
+    testName: string,
+    inputDirectory: string,
+    outputDirectory: string,
+    options: { mode: 'check' | 'update'; quiet: boolean } & Partial<SnapshotOptions>
+): ValidationResults {
+    const results: ValidationResults = {
+        passed: [],
+        failed: [],
+        skipped: []
+    };
+
+    const projectRoot = join(inputDirectory, testName);
+    if (!fs.lstatSync(projectRoot).isDirectory()) {
+        results.failed.push({
+            testName,
+            type: 'missing-output',
+            message: `Test directory does not exist: ${testName}`
+        });
+        return results;
+    }
+
+    try {
+        indexAction({
+            projectName: options.projectName ?? '',
+            projectVersion: options.projectVersion ?? '',
+            projectNamespace: options.projectNamespace,
+            environment: options.environment ? path.resolve(options.environment) : undefined,
+            dev: options.dev ?? false,
+            output: path.join(projectRoot, options.output ?? 'index.scip'),
+            cwd: projectRoot,
+            targetOnly: options.targetOnly,
+            infer: { projectVersionFromCommit: false },
+            quiet: options.quiet,
+            showProgressRateLimit: undefined,
+        });
+    } catch (error) {
+        results.failed.push({
+            testName,
+            type: 'caught-exception',
+            message: `Indexing failed: ${error}`
+        });
+        return results;
+    }
+
+    // Read and validate generated SCIP index
+    const scipIndexPath = path.join(projectRoot, options.output ?? 'index.scip');
+    let scipIndex: scip.Index;
+    
+    try {
+        scipIndex = scip.Index.deserializeBinary(fs.readFileSync(scipIndexPath));
+    } catch (error) {
+        results.failed.push({
+            testName,
+            type: 'caught-exception',
+            message: `Failed to read generated SCIP index: ${error}`
+        });
+        return results;
+    }
+
+    if (scipIndex.documents.length === 0) {
+        results.failed.push({
+            testName,
+            type: 'empty-scip-index',
+            message: 'SCIP index has 0 documents'
+        });
+        return results;
+    }
+
+    if (options.mode === 'check') {
+        const testOutputPath = path.join(outputDirectory, testName);
+        if (!fs.existsSync(testOutputPath)) {
+            results.failed.push({
+                testName,
+                type: 'missing-output' as const,
+                message: `Expected output folder does not exist`
+            });
+            return results;
+        }
+    }
+
+    let tempDir: string | undefined;
+
+    try {
+        if (options.mode !== 'check') {
+            const testOutputDir = path.resolve(outputDirectory, testName);
+            tempDir = createTempDirectory(testOutputDir, testName);
+        }
+        
+        for (const doc of scipIndex.documents) {
+            // FIXME: We should update the SCIP index generation to not generate
+            // relative paths starting with '..'
+            if (doc.relative_path.startsWith('..')) {
+                continue;
+            }
+
+            const inputPath = path.join(projectRoot, doc.relative_path);
+            const input = Input.fromFile(inputPath);
+            const obtained = formatSnapshot(input, doc, scipIndex.external_symbols);
+            const relativeToInputDirectory = path.relative(projectRoot, inputPath);
+            const outputPath = path.resolve(outputDirectory, testName, relativeToInputDirectory);
+
+            if (options.mode === 'check') {
+                const diffResult = diffSnapshot(outputPath, obtained);
+                if (diffResult === 'different') {
+                    results.failed.push({
+                        testName,
+                        type: 'content-mismatch',
+                        message: `Snapshot content mismatch for ${outputPath}`
+                    });
+                }
+            } else {
+                const tempOutputPath = path.join(tempDir!, relativeToInputDirectory);
+                writeSnapshot(tempOutputPath, obtained);
+            }
+        }
+        
+        if (options.mode !== 'check' && tempDir) {
+            const testOutputDir = path.resolve(outputDirectory, testName);
+            replaceFolder(tempDir, testOutputDir);
+            tempDir = undefined; // Mark as consumed to prevent cleanup
+        }
+    } catch (error) {
+        results.failed.push({
+            testName,
+            type: 'caught-exception',
+            message: `Error processing snapshots: ${error}`
+        });
+    } finally {
+        if (tempDir) {
+            cleanupTempDirectory(tempDir);
+        }
+    }
+
+    if (results.failed.length === 0) {
+        results.passed.push(testName);
+    }
+
+    return results;
+}
 
 function testPyprojectParsing() {
     const testCases = [
@@ -91,53 +269,71 @@ function unitTests(): void {
     testPyprojectParsing();
 }
 
-function snapshotTests(mode: 'check' | 'update'): void {
-    const nodePath = process.argv[0];
-    const startCwd = process.cwd();
-    // Returns list of subdir names, not absolute paths.
-    const inputDir = path.join('.', 'snapshots', 'input');
-    const subdirNames = fs.readdirSync(inputDir);
-    const packageInfoPath = path.join('.', 'snapshots', 'packageInfo.json');
+function snapshotTests(mode: 'check' | 'update', failFast: boolean, quiet: boolean, filterTests?: string[]): void {
+    const snapshotRoot = './snapshots';
+    
+    // Load package info to determine project name and version per test
+    const packageInfoPath = path.join(snapshotRoot, 'packageInfo.json');
     const packageInfo = JSON.parse(fs.readFileSync(packageInfoPath, 'utf8'));
-    for (const subdirName of subdirNames) {
-        console.assert(!subdirName.includes(path.sep));
-        let projectName = undefined;
-        let projectVersion = undefined;
-        if (!fs.existsSync(path.join(inputDir, subdirName, 'pyproject.toml'))) {
+    
+    const testRunner = new TestRunner({
+        snapshotRoot,
+        filterTests: filterTests ? filterTests.join(',') : undefined,
+        failFast: failFast,
+        quiet: quiet,
+        mode: mode
+    });
+
+    testRunner.runTests((testName, inputDir, outputDir) => {
+        let projectName: string | undefined;
+        let projectVersion: string | undefined;
+        
+        // Only set project name/version from packageInfo if test doesn't have its own pyproject.toml
+        const testProjectRoot = path.join(inputDir, testName);
+        if (!fs.existsSync(path.join(testProjectRoot, 'pyproject.toml'))) {
             projectName = packageInfo['default']['name'];
             projectVersion = packageInfo['default']['version'];
         }
-        if (subdirName in packageInfo['special']) {
-            projectName = packageInfo['special'][subdirName]['name'];
-            projectVersion = packageInfo['special'][subdirName]['version'];
+        
+        if (testName in packageInfo['special']) {
+            projectName = packageInfo['special'][testName]['name'];
+            projectVersion = packageInfo['special'][testName]['version'];
         }
-        const argv = [
-            nodePath,
-            path.resolve('./index.js'),
-            'snapshot-dir',
-            './snapshots',
-            '--environment',
-            'snapshots/testEnv.json',
-            '--quiet',
-            '--only',
-            subdirName,
-        ]; // FIXME: This should pass with a --dev flag
-        argv.push(...(projectName ? ['--project-name', projectName] : []));
-        argv.push(...(projectVersion ? ['--project-version', projectVersion] : []));
-        if (mode === 'check') {
-            argv.push('--check');
-        }
-        main(argv);
-    }
+
+        return processSingleTest(testName, inputDir, outputDir, {
+            mode: mode,
+            quiet: quiet,
+            ...(projectName && { projectName }),
+            ...(projectVersion && { projectVersion }),
+            environment: path.join(snapshotRoot, 'testEnv.json'),
+            output: 'index.scip',
+            dev: false,
+            cwd: path.join(inputDir, testName),
+            targetOnly: undefined
+        });
+    });
 }
 
-function testMain(mode: 'check' | 'update'): void {
+function testMain(mode: 'check' | 'update', failFast: boolean, quiet: boolean, filterTests?: string[]): void {
     unitTests();
-    snapshotTests(mode);
+    snapshotTests(mode, failFast, quiet, filterTests);
 }
+
+function parseFilterTests(): string[] | undefined {
+    const filterIndex = process.argv.indexOf('--filter-tests');
+    if (filterIndex === -1 || filterIndex + 1 >= process.argv.length) {
+        return undefined;
+    }
+    const filterValue = process.argv[filterIndex + 1];
+    return filterValue.split(',').map(test => test.trim());
+}
+
+const filterTests = parseFilterTests();
+const failFast = (process.argv.indexOf('--fail-fast') !== -1) ?? false;
+const quiet = process.argv.indexOf('--verbose') === -1;
 
 if (process.argv.indexOf('--check') !== -1) {
-    testMain('check');
+    testMain('check', failFast, quiet, filterTests);
 } else {
-    testMain('update');
+    testMain('update', failFast, quiet, filterTests);
 }

--- a/packages/pyright-scip/test/test-main.ts
+++ b/packages/pyright-scip/test/test-main.ts
@@ -8,6 +8,15 @@ import { join } from 'path';
 import * as path from 'path';
 import * as fs from 'fs';
 import { Indexer } from '../src/indexer';
+import {
+    setGlobalAssertionFlags,
+    setGlobalContext,
+    checkSometimesAssertions,
+    SeenCondition
+} from '../src/assertions';
+import { normalizePathCase, isFileSystemCaseSensitive } from 'pyright-internal/common/pathUtils';
+import { PyrightFileSystem } from 'pyright-internal/pyrightFileSystem';
+import { createFromRealFileSystem } from 'pyright-internal/common/realFileSystem';
 
 function createTempDirectory(outputDirectory: string, testName: string): string {
     const tempPrefix = path.join(path.dirname(outputDirectory), `.tmp-${testName}-`);
@@ -271,6 +280,13 @@ function unitTests(): void {
 
 function snapshotTests(mode: 'check' | 'update', failFast: boolean, quiet: boolean, filterTests?: string[]): void {
     const snapshotRoot = './snapshots';
+    const cwd = process.cwd();
+    
+    // Initialize assertion flags
+    const fileSystem = new PyrightFileSystem(createFromRealFileSystem());
+    const pathNormalizationChecks = !isFileSystemCaseSensitive(fileSystem) && normalizePathCase(fileSystem, cwd) !== cwd;
+    const otherChecks = true;
+    setGlobalAssertionFlags(pathNormalizationChecks, otherChecks);
     
     // Load package info to determine project name and version per test
     const packageInfoPath = path.join(snapshotRoot, 'packageInfo.json');
@@ -285,6 +301,9 @@ function snapshotTests(mode: 'check' | 'update', failFast: boolean, quiet: boole
     });
 
     testRunner.runTests((testName, inputDir, outputDir) => {
+        // Set context for this test
+        setGlobalContext(testName);
+        
         let projectName: string | undefined;
         let projectVersion: string | undefined;
         


### PR DESCRIPTION
So it looks like basically there was a bug where the indexer was
generating 0 documents on macOS (related to the recent bug fix in
https://github.com/sourcegraph/scip-python/pull/177/files where we
started normalizing the file paths passed to setTrackedFiles). 😬 

However, the tests were passing on macOS not because they were
correct, but because the zero documents case bypassed the
updating/diffing process. 😢

This patch changes the test diffing logic to be more robust, in handling
various scenarios such as 0 documents. It also introduces a couple
of flags, one for filtering tests, and one for running tests with fail-fast
behavior.

On fixing the tests, I discovered some bugs due to improper handling
of case-sensitivity, so I fixed those (which is why the snapshots are unchanged
and the tests are passing on macOS). For some of these, I'm not super
sure about Pyright behavior, so I added a little assertions library
inspired by Antithesis so that we can test the coverage of different
cases by our test suite on macOS.

See also: https://antithesis.com/docs/best_practices/sometimes_assertions/

- [x] Self-review of changes, since Amp did some of the more low-level stuff.
