### PR TITLE
test ENOBUF workaround

### DIFF
--- a/packages/pyright-scip/src/virtualenv/environment.ts
+++ b/packages/pyright-scip/src/virtualenv/environment.ts
@@ -29,13 +29,15 @@ let getPipCommand = () => {
 };
 
 function pipList(): PipInformation[] {
-    return JSON.parse(child_process.execSync(`${getPipCommand()} list --format=json`).toString()) as PipInformation[];
+    return JSON.parse(
+        child_process.execSync(`${getPipCommand()} list --format=json`, { maxBuffer: 1024 * 1024 * 5 }).toString()
+    ) as PipInformation[];
 }
 
 function pipBulkShow(names: string[]): string[] {
     // TODO: This probably breaks with enough names. Should batch them into 512 or whatever the max for bash would be
     return child_process
-        .execSync(`${getPipCommand()} show -f ${names.join(' ')}`)
+        .execSync(`${getPipCommand()} show -f ${names.join(' ')}`, { maxBuffer: 1024 * 1024 * 5 })
         .toString()
         .split('\n---');
 }

--- a/packages/pyright-scip/src/virtualenv/environment.ts
+++ b/packages/pyright-scip/src/virtualenv/environment.ts
@@ -29,17 +29,28 @@ let getPipCommand = () => {
 };
 
 function pipList(): PipInformation[] {
+    console.log(`Executing pip list.`);
     return JSON.parse(
-        child_process.execSync(`${getPipCommand()} list --format=json`, { maxBuffer: 1024 * 1024 * 5 }).toString()
+        child_process.execSync(`${getPipCommand()} list --format=json`, { maxBuffer: 1024 * 1024 * 100 }).toString()
     ) as PipInformation[];
 }
 
 function pipBulkShow(names: string[]): string[] {
-    // TODO: This probably breaks with enough names. Should batch them into 512 or whatever the max for bash would be
-    return child_process
-        .execSync(`${getPipCommand()} show -f ${names.join(' ')}`, { maxBuffer: 1024 * 1024 * 5 })
-        .toString()
-        .split('\n---');
+    const BATCH_SIZE = 10;
+    const results: string[] = [];
+    console.log(names.length + ' packages to show');
+
+    for (let i = 0; i < names.length; i += BATCH_SIZE) {
+        const batch = names.slice(i, i + BATCH_SIZE);
+        console.log(`Executing pip show for the following packages: ${batch.join(', ')}`);
+        console.log(`${getPipCommand()} show -f ${batch.join(' ')}`);t
+        const output = child_process
+            .execSync(`${getPipCommand()} show -f ${batch.join(' ')}`, { maxBuffer: 1024 * 1024 * 5 })
+            .toString()
+        results.push(...output.split('\n---'));
+    }
+
+    return results;
 }
 
 export default function getEnvironment(


### PR DESCRIPTION
https://github.com/sourcegraph/scip-python/issues/151
For issue detail

We have 615 packages to run,
1 Added `{ maxBuffer: 1024 * 1024 * 5 }` - doesn't help much. Takes too long time.
2 using BATCH_SIZE=512 - still takes too long to run.

<img width="1005" height="262" alt="scip-python-1" src="https://github.com/user-attachments/assets/c2c3fdea-5f3c-4dc3-9bc3-8d1f3fc1a80f" />

