### PR TITLE
Feature: Add file/directory exclusion feature with glob pattern support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,8 @@ tests/broken/
 
 # Glob patterns
 test_*
-**/*.pyc
 build/**
 ```
-
-The exclusion feature supports both exact paths and glob patterns, and works as a filter that gracefully handles non-matching patterns without errors.
 
 ### project-namespace
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,46 @@ To run scip-python over only a particular directory, you can use the `--target-o
 $ scip-python index . --project-name=$MY_PROJECT --target-only=src/subdir
 ```
 
+### exclude
+
+To exclude specific files or directories from indexing, you can use the `--exclude` flag or `--exclude-config` flag. This is useful for skipping broken files, circular dependencies, or test files.
+
+**Exclude via command line:**
+
+```
+$ scip-python index . --project-name=$MY_PROJECT --exclude path/to/broken.py --exclude tests/
+```
+
+**Exclude using glob patterns:**
+
+```
+$ scip-python index . --project-name=$MY_PROJECT --exclude "test_*" "**/*.pyc" "build/**"
+```
+
+**Exclude using a config file:**
+
+```
+$ scip-python index . --project-name=$MY_PROJECT --exclude-config=.scipignore
+```
+
+**Example config file format (`.scipignore`):**
+
+```
+# Broken files
+src/broken_module.py
+
+# Directories with circular dependencies
+src/experimental/
+tests/broken/
+
+# Glob patterns
+test_*
+**/*.pyc
+build/**
+```
+
+The exclusion feature supports both exact paths and glob patterns, and works as a filter that gracefully handles non-matching patterns without errors.
+
 ### project-namespace
 
 Additionally, if your project is loaded with some prefix, you can use the `--project-namespace` to put a namespace before all the generated symbols for this project.

--- a/packages/pyright-scip/package-lock.json
+++ b/packages/pyright-scip/package-lock.json
@@ -15,6 +15,7 @@
                 "diff": "^5.0.0",
                 "glob": "^7.2.0",
                 "google-protobuf": "^3.19.3",
+                "minimatch": "^10.0.3",
                 "ts-node": "^10.5.0",
                 "vscode-languageserver": "^7.0.0"
             },
@@ -756,6 +757,20 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -771,6 +786,20 @@
                 "node": ">=10.10.0"
             }
         },
+        "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/@humanwhocodes/object-schema": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
@@ -782,6 +811,27 @@
             "version": "2.2.5",
             "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
             "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
+        },
+        "node_modules/@isaacs/balanced-match": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+            "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@isaacs/brace-expansion": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+            "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+            "license": "MIT",
+            "dependencies": {
+                "@isaacs/balanced-match": "^4.0.1"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            }
         },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
@@ -2576,7 +2626,8 @@
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "license": "MIT"
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
@@ -2621,9 +2672,10 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3009,7 +3061,8 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "license": "MIT"
         },
         "node_modules/convert-source-map": {
             "version": "1.8.0",
@@ -3795,6 +3848,19 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/eslint-plugin-import/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/eslint-plugin-import/node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -3867,6 +3933,19 @@
                 "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
             }
         },
+        "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/eslint-plugin-react": {
             "version": "7.29.4",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.4.tgz",
@@ -3917,6 +3996,19 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/eslint-plugin-react/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/eslint-plugin-react/node_modules/resolve": {
@@ -4161,6 +4253,20 @@
             "peer": true,
             "engines": {
                 "node": ">= 4"
+            }
+        },
+        "node_modules/eslint/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/espree": {
@@ -4620,6 +4726,18 @@
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
             "dev": true
+        },
+        "node_modules/glob/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
         },
         "node_modules/globals": {
             "version": "13.13.0",
@@ -7163,14 +7281,18 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+            "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+            "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^1.1.7"
+                "@isaacs/brace-expansion": "^5.0.0"
             },
             "engines": {
-                "node": "*"
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/minimist": {
@@ -8893,6 +9015,19 @@
                 "node": ">=8"
             }
         },
+        "node_modules/test-exclude/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -10336,6 +10471,16 @@
                     "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
                     "dev": true,
                     "peer": true
+                },
+                "minimatch": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                    "dev": true,
+                    "peer": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
                 }
             }
         },
@@ -10349,6 +10494,18 @@
                 "@humanwhocodes/object-schema": "^1.2.0",
                 "debug": "^4.1.1",
                 "minimatch": "^3.0.4"
+            },
+            "dependencies": {
+                "minimatch": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                    "dev": true,
+                    "peer": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                }
             }
         },
         "@humanwhocodes/object-schema": {
@@ -10362,6 +10519,19 @@
             "version": "2.2.5",
             "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
             "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
+        },
+        "@isaacs/balanced-match": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+            "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="
+        },
+        "@isaacs/brace-expansion": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+            "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+            "requires": {
+                "@isaacs/balanced-match": "^4.0.1"
+            }
         },
         "@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
@@ -11873,9 +12043,9 @@
             }
         },
         "brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -12151,7 +12321,7 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
         },
         "convert-source-map": {
             "version": "1.8.0",
@@ -12654,6 +12824,16 @@
                     "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
                     "dev": true,
                     "peer": true
+                },
+                "minimatch": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                    "dev": true,
+                    "peer": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
                 }
             }
         },
@@ -12791,6 +12971,15 @@
                         "esutils": "^2.0.2"
                     }
                 },
+                "minimatch": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -12843,6 +13032,17 @@
                 "jsx-ast-utils": "^3.2.1",
                 "language-tags": "^1.0.5",
                 "minimatch": "^3.0.4"
+            },
+            "dependencies": {
+                "minimatch": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                }
             }
         },
         "eslint-plugin-react": {
@@ -12874,6 +13074,15 @@
                     "dev": true,
                     "requires": {
                         "esutils": "^2.0.2"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "resolve": {
@@ -13354,6 +13563,16 @@
                 "minimatch": "^3.0.4",
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
+            },
+            "dependencies": {
+                "minimatch": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                }
             }
         },
         "glob-parent": {
@@ -15347,11 +15566,11 @@
             "dev": true
         },
         "minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+            "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
             "requires": {
-                "brace-expansion": "^1.1.7"
+                "@isaacs/brace-expansion": "^5.0.0"
             }
         },
         "minimist": {
@@ -16617,6 +16836,17 @@
                 "@istanbuljs/schema": "^0.1.2",
                 "glob": "^7.1.4",
                 "minimatch": "^3.0.4"
+            },
+            "dependencies": {
+                "minimatch": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                }
             }
         },
         "text-table": {

--- a/packages/pyright-scip/package.json
+++ b/packages/pyright-scip/package.json
@@ -52,6 +52,7 @@
         "diff": "^5.0.0",
         "glob": "^7.2.0",
         "google-protobuf": "^3.19.3",
+        "minimatch": "^10.0.3",
         "ts-node": "^10.5.0",
         "vscode-languageserver": "^7.0.0"
     },

--- a/packages/pyright-scip/src/MainCommand.ts
+++ b/packages/pyright-scip/src/MainCommand.ts
@@ -10,6 +10,8 @@ export interface IndexOptions {
     output: string;
     cwd: string;
     targetOnly?: string;
+    exclude?: string[];
+    excludeConfig?: string;
     infer?: { projectVersionFromCommit: boolean };
 
     // Progress reporting configuration
@@ -64,6 +66,8 @@ export function mainCommand(
         .option('--project-namespace <namespace>', 'A prefix to prepend to all module definitions in the current index')
         .option('--cwd <path>', 'working directory for executing scip-python', process.cwd())
         .option('--target-only <path>', 'limit analysis to the following path')
+        .option('--exclude <paths...>', 'exclude files or directories from analysis (can specify multiple)')
+        .option('--exclude-config <file>', 'path to a config file containing paths to exclude (one per line)')
         .option(
             '--output <path>',
             'Path to the output file. If this path is relative, it is interpreted relative to the value for --cwd.',

--- a/packages/pyright-scip/src/indexer.ts
+++ b/packages/pyright-scip/src/indexer.ts
@@ -133,9 +133,10 @@ export class Indexer {
                 const configPath = path.resolve(scipConfig.excludeConfig);
                 if (fs.existsSync(configPath)) {
                     const configContent = fs.readFileSync(configPath, 'utf8');
-                    const lines = configContent.split('\n')
-                        .map(line => line.trim())
-                        .filter(line => line && !line.startsWith('#')); // Ignore empty lines and comments
+                    const lines = configContent
+                        .split('\n')
+                        .map((line) => line.trim())
+                        .filter((line) => line && !line.startsWith('#')); // Ignore empty lines and comments
                     excludePatterns.push(...lines);
                 } else {
                     sendStatus(`Warning: Exclude config file not found: ${configPath}`);
@@ -148,7 +149,9 @@ export class Indexer {
                 let shouldExclude = false;
 
                 for (const pattern of excludePatterns) {
-                    const resolvedPattern = path.isAbsolute(pattern) ? pattern : path.resolve(scipConfig.projectRoot, pattern);
+                    const resolvedPattern = path.isAbsolute(pattern)
+                        ? pattern
+                        : path.resolve(scipConfig.projectRoot, pattern);
 
                     // Check exact path match or directory prefix
                     if (file === resolvedPattern || file.startsWith(resolvedPattern + path.sep)) {

--- a/packages/pyright-scip/src/indexer.ts
+++ b/packages/pyright-scip/src/indexer.ts
@@ -1,7 +1,9 @@
 import * as child_process from 'child_process';
+import * as fs from 'fs';
 import * as path from 'path';
 import * as TOML from '@iarna/toml';
 import { Event } from 'vscode-languageserver/lib/common/api';
+import { minimatch } from 'minimatch';
 
 import { Program } from 'pyright-internal/analyzer/program';
 import { ImportResolver } from 'pyright-internal/analyzer/importResolver';
@@ -115,6 +117,65 @@ export class Indexer {
             }
 
             this.projectFiles = targetFiles;
+        }
+
+        // Apply exclusions
+        if (scipConfig.exclude || scipConfig.excludeConfig) {
+            const excludePatterns: string[] = [];
+
+            // Add patterns from --exclude flag
+            if (scipConfig.exclude) {
+                excludePatterns.push(...scipConfig.exclude);
+            }
+
+            // Add patterns from --exclude-config file
+            if (scipConfig.excludeConfig) {
+                const configPath = path.resolve(scipConfig.excludeConfig);
+                if (fs.existsSync(configPath)) {
+                    const configContent = fs.readFileSync(configPath, 'utf8');
+                    const lines = configContent.split('\n')
+                        .map(line => line.trim())
+                        .filter(line => line && !line.startsWith('#')); // Ignore empty lines and comments
+                    excludePatterns.push(...lines);
+                } else {
+                    sendStatus(`Warning: Exclude config file not found: ${configPath}`);
+                }
+            }
+
+            // Filter out excluded files using pattern matching
+            const filteredFiles: Set<string> = new Set();
+            for (const file of this.projectFiles) {
+                let shouldExclude = false;
+
+                for (const pattern of excludePatterns) {
+                    const resolvedPattern = path.isAbsolute(pattern) ? pattern : path.resolve(scipConfig.projectRoot, pattern);
+
+                    // Check exact path match or directory prefix
+                    if (file === resolvedPattern || file.startsWith(resolvedPattern + path.sep)) {
+                        shouldExclude = true;
+                        break;
+                    }
+
+                    // Check glob pattern match (relative to project root)
+                    const relativePath = path.relative(scipConfig.projectRoot, file);
+                    if (minimatch(relativePath, pattern, { dot: true, matchBase: true })) {
+                        shouldExclude = true;
+                        break;
+                    }
+
+                    // Also try matching absolute path against pattern
+                    if (minimatch(file, resolvedPattern, { dot: true })) {
+                        shouldExclude = true;
+                        break;
+                    }
+                }
+
+                if (!shouldExclude) {
+                    filteredFiles.add(file);
+                }
+            }
+
+            this.projectFiles = filteredFiles;
         }
 
         sendStatus(`Total Project Files ${this.projectFiles.size}`);


### PR DESCRIPTION
## Motivation

The motivation of the PR is in many repositories; we don't want to include some files, e.g., tests*)
and it may also include a file that would be either broken or meaningless. However, all these files will not only affect the processing time of pyright-scip, but also will cause abortion. One example I showed below is the failed log while I process the sympy repo. I also attached the success log after applying our new `exclude` pattern. 



### Summary

This PR adds the ability to exclude files and directories from SCIP indexing using command-line flags or a configuration file. The exclusion feature supports both exact paths and glob patterns (e.g., `test_*`), and works as a filter that gracefully handles non-matching patterns without errors.

### Changes Made

**1. MainCommand.ts**

- Added `exclude?: string[]` to `IndexOptions` interface
- Added `excludeConfig?: string` to `IndexOptions` interface
- Added `--exclude <paths...>` flag to accept multiple file/directory paths
- Added `--exclude-config <file>` flag to accept a config file with exclusion paths

**2. indexer.ts**

- Added `import { minimatch } from 'minimatch'` for glob pattern matching
- Implemented exclusion logic after `targetOnly` filtering (lines 122-179)
- Reads patterns from `--exclude` flag
- Reads patterns from config file if `--exclude-config` is provided
- Config file supports:
- Pattern matching features:
- Exact path matching (original functionality)
- Glob patterns: `dir*`, `file*`, `tests/**`, etc.
- Relative and absolute paths
- Works as a filter - patterns matching nothing don't cause errors

**3. package.json**

- Added `minimatch` dependency for glob pattern matching

### Usage

- ***Exclude specific files/directories via command line:****

```bash

scip-python index --project-name=myproject --exclude path/to/broken.py --exclude path/to/circular/

```

- ***Exclude using patterns:****

```bash

scip-python index --project-name=myproject --exclude "test_*" "build/**"

```

- ***Exclude using a config file:****

```bash

scip-python index --project-name=myproject --exclude-config=.scipignore

```

- ***Example config file format (`.scipignore`):****

```

# Broken files

src/broken_module.py

# Directories with circular dependencies

src/experimental/

tests/broken/

# Glob patterns

test_*

build/**

# Another problematic file

lib/legacy.py

```

### Benefits

- ***Flexibility***: Supports both exact paths and glob patterns
- ***Robustness***: Works as a filter - no errors if patterns match nothing
- ***Usability***: Config file support for managing complex exclusion rules
- ***Consistency***: Follows the same pattern as existing `--target-only` flag

### Testing

The feature can be tested by:

1. Using `--exclude` with exact paths

2. Using `--exclude` with glob patterns like `test_*`

3. Using `--exclude-config` with a file containing mixed patterns and comments

4. Verifying that non-matching patterns don't cause errors




### Log when directly indexing the sympy

```
(11:57:21) pyproject.toml file found at /home/zhongming/.codeminer/sympy_sympy.
(11:57:21) Loading pyproject.toml file at /home/zhongming/.codeminer/sympy_sympy/pyproject.toml
Assuming Python version 3.11
Assuming Python platform Linux
Auto-excluding **/node_modules
Auto-excluding **/**pycache**
Auto-excluding **/.*
(11:57:21) Total Project Files 1522
(11:57:21) Indexing /home/zhongming/.codeminer/sympy_sympy with version d293133e81194adc11177729af91c970f092a6e7
(11:57:21) Evaluating python environment dependencies
(11:57:21)   Gathering environment information
(11:57:22) Parse and search for dependencies
(11:57:32)   152 / 1522
(11:57:43)   211 / 1522
(11:57:57)   377 / 1522
(11:58:07)   577 / 1522
(11:58:17)   864 / 1522
(11:58:27)   958 / 1522
(11:58:51)   1084 / 1522
(11:59:01)   1276 / 1522
(11:59:11)   1419 / 1522
(11:59:14) Index workspace and track project files
(11:59:14) Analyze project and dependencies
(11:59:26)   76 / 1524
(11:59:37)   114 / 1524
(11:59:47)   165 / 1524
(11:59:57)   224 / 1524
(12:00:08)   264 / 1524
(12:00:33)   301 / 1524
(12:00:43)   432 / 1524
(12:00:53)   477 / 1524
(12:01:03)   526 / 1524
(12:01:13)   584 / 1524
(12:01:25)   614 / 1524
(12:01:37)   642 / 1524

<--- Last few GCs --->

[2024902:0x7c30a30]   258240 ms: Mark-Compact 3985.9 (4128.9) -> 3970.3 (4129.4) MB, 1982.51 / 0.00 ms  (average mu = 0.180, current mu = 0.020) allocation failure; scavenge might not succeed
[2024902:0x7c30a30]   260659 ms: Mark-Compact 3986.5 (4129.4) -> 3970.9 (4129.9) MB, 2370.20 / 0.00 ms  (average mu = 0.103, current mu = 0.020) allocation failure; scavenge might not succeed

<--- JS stacktrace --->

FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
----- Native stack trace -----

1: 0xb8d0a3 node::OOMErrorHandler(char const*, v8::OOMDetails const&) [node]
2: 0xf06250 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node]
3: 0xf06537 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node]
4: 0x11180d5  [node]
5: 0x1118664 v8::internal::Heap::RecomputeLimits(v8::internal::GarbageCollector) [node]
6: 0x112f554 v8::internal::Heap::PerformGarbageCollection(v8::internal::GarbageCollector, v8::internal::GarbageCollectionReason, char const*) [node]
7: 0x112fd6c v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [node]
8: 0x1106071 v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node]
9: 0x1107205 v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node]
10: 0x10e4856 v8::internal::Factory::NewFillerObject(int, v8::internal::AllocationAlignment, v8::internal::AllocationType, v8::internal::AllocationOrigin) [node]
11: 0x1540686 v8::internal::Runtime_AllocateInYoungGeneration(int, unsigned long*, v8::internal::Isolate*) [node]
12: 0x7ecdc3cd9ef6
```

### Log after the exclude feature applied
```
INFO     Running in conda environment: ['scip-python', 'index', '--cwd', '/home/zhongming/.codeminer/sympy_sympy',

'--project-name', 'test_swebench', '--output', '/home/zhongming/.codeminer/sympy__sympy-27223/index.scip',

'--exclude', 'sympy/polys/numberfields/resolvent_lookup.py', '--exclude', 'test_*']

(13:28:16) No configuration file found.
(13:28:16) pyproject.toml file found at /home/zhongming/.codeminer/sympy_sympy.
(13:28:16) Loading pyproject.toml file at /home/zhongming/.codeminer/sympy_sympy/pyproject.toml
Assuming Python version 3.11
Assuming Python platform Linux
Auto-excluding **/node_modules
Auto-excluding **/**pycache**
Auto-excluding **/.*
(13:28:16) Total Project Files 915
(13:28:16) Indexing /home/zhongming/.codeminer/sympy_sympy with version d293133e81194adc11177729af91c970f092a6e7
(13:28:16) Evaluating python environment dependencies
(13:28:17)   Gathering environment information
(13:28:17) Parse and search for dependencies
(13:28:28)   101 / 915
(13:28:43)   226 / 915
(13:28:53)   515 / 915
(13:29:04)   591 / 915
(13:29:14)   786 / 915
(13:29:17) Index workspace and track project files
(13:29:17) Analyze project and dependencies
(13:29:27)   28 / 917
(13:29:37)   145 / 917
(13:29:49)   163 / 917
(13:29:59)   480 / 917
(13:30:11)   508 / 917
(13:30:21)   684 / 917
(13:30:28) Parse and emit SCIP
(13:30:29)   - (14/916): /home/zhongming/.codeminer/sympy_sympy/sympy/assumptions/facts.py
(13:30:30)   - (48/916): /home/zhongming/.codeminer/sympy_sympy/sympy/calculus/tests/**init**.py
(13:30:31)   - (74/916): /home/zhongming/.codeminer/sympy_sympy/sympy/combinatorics/free_groups.py
(13:30:33)   - (85/916): /home/zhongming/.codeminer/sympy_sympy/sympy/combinatorics/permutations.py
(13:30:34)   - (120/916): /home/zhongming/.codeminer/sympy_sympy/sympy/core/expr.py
(13:30:35)   - (129/916): /home/zhongming/.codeminer/sympy_sympy/sympy/core/multidimensional.py
(13:30:36)   - (177/916): /home/zhongming/.codeminer/sympy_sympy/sympy/functions/elementary/exponential.py
(13:30:38)   - (218/916): /home/zhongming/.codeminer/sympy_sympy/sympy/holonomic/holonomicerrors.py
(13:30:39)   - (264/916): /home/zhongming/.codeminer/sympy_sympy/sympy/logic/inference.py
(13:30:40)   - (339/916): /home/zhongming/.codeminer/sympy_sympy/sympy/ntheory/generate.py
(13:30:41)   - (355/916): /home/zhongming/.codeminer/sympy_sympy/sympy/parsing/autolev/_listener_autolev_antlr.py
(13:30:42)   - (381/916): /home/zhongming/.codeminer/sympy_sympy/sympy/parsing/latex/**init**.py
(13:30:43)   - (474/916): /home/zhongming/.codeminer/sympy_sympy/sympy/physics/quantum/qft.py
(13:30:44)   - (573/916): /home/zhongming/.codeminer/sympy_sympy/sympy/polys/polyconfig.py
(13:30:46)   - (581/916): /home/zhongming/.codeminer/sympy_sympy/sympy/polys/polyutils.py
(13:30:47)   - (654/916): /home/zhongming/.codeminer/sympy_sympy/sympy/polys/numberfields/galoisgroups.py
(13:30:48)   - (699/916): /home/zhongming/.codeminer/sympy_sympy/sympy/printing/pretty/pretty_symbology.py
(13:30:49)   - (771/916): /home/zhongming/.codeminer/sympy_sympy/sympy/solvers/solveset.py
(13:30:50)   - (808/916): /home/zhongming/.codeminer/sympy_sympy/sympy/stats/sampling/**init**.py
(13:30:51)   - (832/916): /home/zhongming/.codeminer/sympy_sympy/sympy/tensor/toperators.py
(13:30:52)   - (902/916): /home/zhongming/.codeminer/sympy_sympy/sympy/vector/deloperator.py
(13:30:53) Writing external symbols to SCIP index
(13:30:53) Sucessfully wrote SCIP index to /home/zhongming/.codeminer/sympy__sympy-27223/index.scip
```