### PR TITLE
fix: replace @iarna/toml with smol-toml for TOML 1.0 and PEP 735 support

### DIFF
--- a/packages/pyright-internal/package.json
+++ b/packages/pyright-internal/package.json
@@ -15,7 +15,7 @@
         "test:coverage": "jest --forceExit --reporters=jest-junit --reporters=default --coverage --coverageReporters=cobertura --coverageReporters=html --coverageReporters=json"
     },
     "dependencies": {
-        "@iarna/toml": "2.2.5",
+        "smol-toml": "^1.6.1",
         "@yarnpkg/fslib": "2.10.1",
         "@yarnpkg/libzip": "2.2.4",
         "chalk": "^4.1.2",

--- a/packages/pyright-internal/src/analyzer/service.ts
+++ b/packages/pyright-internal/src/analyzer/service.ts
@@ -8,7 +8,7 @@
  * Python files.
  */
 
-import * as TOML from '@iarna/toml';
+import * as TOML from 'smol-toml';
 import * as JSONC from 'jsonc-parser';
 import {
     AbstractCancellationTokenSource,
@@ -1072,9 +1072,9 @@ export class AnalyzerService {
     private _parsePyprojectTomlFile(pyprojectPath: string): object | undefined {
         return this._attemptParseFile(pyprojectPath, (fileContents, attemptCount) => {
             try {
-                const configObj = TOML.parse(fileContents);
-                if (configObj && configObj.tool && (configObj.tool as TOML.JsonMap).pyright) {
-                    return (configObj.tool as TOML.JsonMap).pyright as object;
+                const configObj = TOML.parse(fileContents) as Record<string, any>;
+                if (configObj && configObj.tool && configObj.tool.pyright) {
+                    return configObj.tool.pyright as object;
                 }
             } catch (e: any) {
                 this._console.error(`Pyproject file parse attempt ${attemptCount} error: ${JSON.stringify(e)}`);

--- a/packages/pyright-scip/package.json
+++ b/packages/pyright-scip/package.json
@@ -46,7 +46,7 @@
         "webpack-cli": "^4.9.1"
     },
     "dependencies": {
-        "@iarna/toml": "^2.2.5",
+        "smol-toml": "^1.6.1",
         "command-exists": "^1.2.9",
         "commander": "^9.2.0",
         "diff": "^5.0.0",

--- a/packages/pyright-scip/src/config.ts
+++ b/packages/pyright-scip/src/config.ts
@@ -1,4 +1,4 @@
-import * as TOML from '@iarna/toml';
+import * as TOML from 'smol-toml';
 import * as JSONC from 'jsonc-parser';
 import { findPythonSearchPaths, getTypeShedFallbackPath } from 'pyright-internal/analyzer/pythonPathUtils';
 
@@ -427,14 +427,14 @@ export class ScipPyrightConfig {
         return this._attemptParseFile(pyprojectPath, (fileContents, attemptCount) => {
             try {
                 // First, try and load tool.scip section
-                const configObj = TOML.parse(fileContents);
-                if (configObj && configObj.tool && (configObj.tool as TOML.JsonMap).scip) {
-                    return (configObj.tool as TOML.JsonMap).scip as object;
+                const configObj = TOML.parse(fileContents) as Record<string, any>;
+                if (configObj && configObj.tool && configObj.tool.scip) {
+                    return configObj.tool.scip as object;
                 }
 
                 // Fall back to tool.pyright section
-                if (configObj && configObj.tool && (configObj.tool as TOML.JsonMap).pyright) {
-                    return (configObj.tool as TOML.JsonMap).pyright as object;
+                if (configObj && configObj.tool && configObj.tool.pyright) {
+                    return configObj.tool.pyright as object;
                 }
             } catch (e: any) {
                 this._console.error(`Pyproject file parse attempt ${attemptCount} error: ${JSON.stringify(e)}`);

--- a/packages/pyright-scip/src/indexer.ts
+++ b/packages/pyright-scip/src/indexer.ts
@@ -1,6 +1,6 @@
 import * as child_process from 'child_process';
 import * as path from 'path';
-import * as TOML from '@iarna/toml';
+import * as TOML from 'smol-toml';
 import { Event } from 'vscode-languageserver/lib/common/api';
 
 import { Program } from 'pyright-internal/analyzer/program';
@@ -39,18 +39,18 @@ export class Indexer {
         try {
             const pyprojectTomlContents = getPyprojectTomlContents();
             if (pyprojectTomlContents) {
-                const tomlMap = TOML.parse(pyprojectTomlContents);
+                const tomlMap = TOML.parse(pyprojectTomlContents) as Record<string, any>;
                 // See: https://packaging.python.org/en/latest/specifications/declaring-project-metadata/#specification
-                let project = tomlMap['project'] as TOML.JsonMap | undefined;
+                let project = tomlMap['project'];
                 if (project) {
                     name = project['name'];
                     version = project['version'];
                 }
                 if (!name || !version) {
                     // See: https://python-poetry.org/docs/pyproject/
-                    let tool = tomlMap['tool'] as TOML.JsonMap | undefined;
+                    let tool = tomlMap['tool'];
                     if (tool) {
-                        let toolPoetry = tool['poetry'] as TOML.JsonMap | undefined;
+                        let toolPoetry = tool['poetry'];
                         if (toolPoetry) {
                             name = name ?? toolPoetry['name'];
                             version = version ?? toolPoetry['version'];


### PR DESCRIPTION
Fixes #207

## Problem

@iarna/toml fails to parse mixed-type arrays (inline tables + strings) which is valid TOML 1.0 syntax used by PEP 735 dependency groups.

## Error

[dependency-groups]
dev = [
    {include-group = "test"},  # inline table
    "ml_stack_document_extraction",  # string
]

Results in:
TomlError: line 66, col 34
Config file "pyproject.toml" could not be parsed.

## Solution

Replace @iarna/toml (unmaintained since 2019) with smol-toml - a modern, actively maintained TOML parser that correctly handles TOML 1.0 syntax.

## Changes

- Replace @iarna/toml with smol-toml in dependencies
- Update imports and remove TOML.JsonMap type references

## Testing

- Build successful
- All existing tests pass
- Correctly parses pyproject.toml with PEP 735 syntax