### PR TITLE
Fix Windows path separator regex escaping

### DIFF
--- a/packages/pyright-scip/src/virtualenv/PythonEnvironment.ts
+++ b/packages/pyright-scip/src/virtualenv/PythonEnvironment.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import PythonPackage from './PythonPackage';
 
-const pathSepRegex = new RegExp(path.sep, 'g');
+const pathSepRegex = new RegExp(path.sep.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&'), 'g');
 
 export default class PythonEnvironment {
     /// Maps a module name (x.y.z) to an index in this.packages


### PR DESCRIPTION
## Summary
Escapes `path.sep` before using it in `new RegExp(...)` inside `PythonEnvironment`.

This fixes a Windows startup crash where `path.sep === \` and the current code throws:

```
Invalid regular expression: /\\/g: \\ at end of pattern
```

## Verification
- Reproduced on Windows with `@sourcegraph/scip-python@0.6.6`
- Verified locally that this patch removes the crash
- Verified `scip-python index` completes successfully on a real Python project after the change

Closes #210.