### PR TITLE
fix: Error out on undetermined project version

### DIFF
--- a/packages/pyright-scip/src/indexer.ts
+++ b/packages/pyright-scip/src/indexer.ts
@@ -23,6 +23,13 @@ import { scip } from './scip';
 import { ScipPyrightConfig } from './config';
 import { setProjectNamespace } from './symbols';
 
+export class MissingProjectVersionError extends Error {
+    constructor() {
+        super('Could not determine the project version.');
+        this.name = 'MissingProjectVersionError';
+    }
+}
+
 export class Indexer {
     program: Program;
     importResolver: ImportResolver;
@@ -101,6 +108,14 @@ export class Indexer {
             if (!scipConfig.projectVersion && version) {
                 scipConfig.projectVersion = version;
             }
+        }
+
+        // The version can still be undefined here, e.g. when it is declared
+        // dynamically (PEP 621 dynamic = ["version"]) and could not be
+        // inferred. Bail out with an actionable error rather than baking a
+        // bogus version into every symbol.
+        if (!scipConfig.projectVersion) {
+            throw new MissingProjectVersionError();
         }
 
         const matcher = new FileMatcher(this.pyrightConfig, fs);

--- a/packages/pyright-scip/src/main-impl.ts
+++ b/packages/pyright-scip/src/main-impl.ts
@@ -7,7 +7,7 @@ import { Input } from './lsif-typescript/Input';
 import { join } from 'path';
 import { IndexOptions, SnapshotOptions, mainCommand } from './MainCommand';
 import { sendStatus, setQuiet, setShowProgressRateLimit } from './status';
-import { Indexer } from './indexer';
+import { Indexer, MissingProjectVersionError } from './indexer';
 import { exit } from 'process';
 
 export function indexAction(options: IndexOptions): void {
@@ -46,10 +46,16 @@ export function indexAction(options: IndexOptions): void {
 
         indexer.index();
     } catch (e) {
-        console.warn(
-            '\n\nExperienced Fatal Error While Indexing:\nPlease create an issue at github.com/sourcegraph/scip-python:',
-            e
-        );
+        if (e instanceof MissingProjectVersionError) {
+            console.error(
+                'Could not determine the project version. Pass one explicitly with --project-version.'
+            );
+        } else {
+            console.warn(
+                '\n\nExperienced Fatal Error While Indexing:\nPlease create an issue at github.com/sourcegraph/scip-python:',
+                e
+            );
+        }
         process.chdir(originalWorkdir);
         exit(1);
     }


### PR DESCRIPTION
Indexing crashed with "TypeError: Cannot read properties of undefined (reading 'indexOf')" on projects that declare their version dynamically (PEP 621 dynamic = ["version"]) when it could not be inferred. The project version stayed undefined and normalizeNameOrVersion dereferenced it.

Throw a dedicated error instead, so indexing fails up front with a hint to pass --project-version rather than baking a bogus version into every symbol or crashing downstream.