### PR TITLE
Enable autoSearchPaths to match pyright's CLI

### DIFF
--- a/packages/pyright-scip/src/config.ts
+++ b/packages/pyright-scip/src/config.ts
@@ -47,6 +47,15 @@ export class ScipPyrightConfig {
         // TODO: This probably should be ScipConfig.workspaceroot or similar?
         const options = new CommandLineOptions(process.cwd(), false);
 
+        // Match pyright's CLI, which always enables this (see pyright.ts:
+        // "Always enable autoSearchPaths when using the command line.").
+        // Without it, ensureDefaultExtraPaths() below never adds ./src, so
+        // src-layout projects resolve definitions under `src.pkg.mod` while
+        // imports resolve to `pkg.mod`, and cross-package references are lost.
+        // An explicit extraPaths in pyrightconfig.json / [tool.pyright] still
+        // takes precedence, so configured projects are unaffected.
+        options.autoSearchPaths = true;
+
         let config = this._getConfigOptions(host, options);
         config.checkOnlyOpenFiles = false;
         config.indexing = true;


### PR DESCRIPTION
Fixes #221.

`scip-python` builds its own `CommandLineOptions` and never sets `autoSearchPaths`, so
`ensureDefaultExtraPaths()` never adds `./src`. pyright's CLI sets it unconditionally:

```ts
// pyright-internal/src/pyright.ts
// Always enable autoSearchPaths when using the command line.
options.configSettings.autoSearchPaths = true;
```

Since `pyright-scip` replaces that entry point, the setting is lost, and `src`-layout projects
index with definitions under `src.pkg.mod` while imports resolve to `pkg.mod`. The two namespaces
never join, so cross-package references are dropped. The run exits 0 and the index is just smaller.

## Verification

Minimal project, no `[tool.pyright]` section:

```
demo/
├── pyproject.toml       # [project] name = "demo", version = "0.1.0"
├── src/demo/__init__.py
├── src/demo/core.py     # def handler() -> int: return 1
└── tests/test_core.py   # from demo.core import handler
```

**Before** — the reference to `handler` is absent entirely:

```
src/demo/core.py
    def: scip-python python demo 0.1.0 `src.demo.core`/handler().
tests/test_core.py
    ref: scip-python python demo 0.1.0 `demo.core`/__init__:
```

**After** (equivalently, with `extraPaths = ["src"]` set manually on 0.6.6):

```
src/demo/core.py
    def: scip-python python demo 0.1.0 `demo.core`/handler().
tests/test_core.py
    ref: scip-python python demo 0.1.0 `demo.core`/handler().
    ref: scip-python python demo 0.1.0 `demo.core`/handler().
```

For comparison, `pyright` itself resolves this tree with no configuration at all — same directory,
no `[tool.pyright]`:

```
$ npx pyright@latest --outputjson
{ "summary": { "filesAnalyzed": 3, "errorCount": 0, ... } }
```

So `pyright` and `scip-python` currently disagree about the same project.

## Safety

`ensureDefaultExtraPaths` applies `autoSearchPaths` and explicit `extraPaths` independently, and
the auto-detected path is only added when `./src` exists **and** is not itself a package
(`src/__init__.py` absent). Projects that already configure `extraPaths` in `pyrightconfig.json`
or `[tool.pyright]` are unaffected; projects with a `src` package directory are unaffected.

## Note on tests

I did not add a snapshot fixture. A `snapshots/input/src_layout/` case (a `src/`-rooted package
plus an importer outside `src/`) would cover this well, but the expected output has to come from
`npm run update-snapshots` against a build, and I would rather not hand-write generated output I
can't verify. Happy to add it if you'd like — just say the word and I'll build and generate it
properly.

## Environment

- verified against `scip` branch and `@sourcegraph/scip-python` 0.6.6 (current npm latest)
- compared against `pyright` 1.1.411
- Node v24.13.0, Linux
