### PR TITLE
Fix Windows path separator handling

### DIFF
--- a/packages/pyright-scip/src/virtualenv/PythonEnvironment.test.ts
+++ b/packages/pyright-scip/src/virtualenv/PythonEnvironment.test.ts
@@ -1,0 +1,10 @@
+import PythonEnvironment from './PythonEnvironment';
+import PythonPackage from './PythonPackage';
+
+test('resolves module paths with Windows and POSIX separators', () => {
+    const packageInfo = new PythonPackage('example', '1.0.0', ['example\\windows.py', 'example/posix.py']);
+    const environment = new PythonEnvironment(new Set(packageInfo.files), '1.0.0', [packageInfo]);
+
+    expect(environment.getPackageForModule('example.windows')).toBe(packageInfo);
+    expect(environment.getPackageForModule('example.posix')).toBe(packageInfo);
+});

--- a/packages/pyright-scip/src/virtualenv/PythonEnvironment.ts
+++ b/packages/pyright-scip/src/virtualenv/PythonEnvironment.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import PythonPackage from './PythonPackage';
 
-const pathSepRegex = new RegExp(path.sep, 'g');
+const pathSepRegex = /[\\/]/g;
 
 export default class PythonEnvironment {
     /// Maps a module name (x.y.z) to an index in this.packages


### PR DESCRIPTION
## What changed

- replace the platform-derived regular expression with a separator expression that safely handles both `\` and `/`
- add a regression test covering Windows and POSIX paths

## Why

On Windows, `path.sep` is `\`. Passing it directly to `new RegExp()` creates an invalid regular expression and crashes `scip-python` during module initialization. This addresses #210.

Accepting both separators also keeps package resolution robust when Python metadata contains mixed path styles.

## Validation

- `npm test -- --runInBand` — 2 suites, 8 tests passed
- `npm run check:prettier` — passed
- `npm run build-agent` — passed
- native Windows indexing smoke — generated a SCIP index containing all 8 expected Python documents